### PR TITLE
[Feat/#16] 활동 관리 화면의 전반적인 UI 구조 설계

### DIFF
--- a/presentation/src/main/java/com/umc/presentation/MainActivity.kt
+++ b/presentation/src/main/java/com/umc/presentation/MainActivity.kt
@@ -1,6 +1,7 @@
 package com.umc.presentation
 
 import android.view.View
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
 import androidx.navigation.NavController
 import androidx.navigation.findNavController
@@ -19,6 +20,8 @@ class MainActivity : BaseActivity<ActivityMainBinding, MainActivityUiState, Main
     private lateinit var navController: NavController
 
     override fun initView() {
+        enableEdgeToEdge()
+
         binding.apply {
             vm = viewModel
             initNavigation()
@@ -57,12 +60,10 @@ class MainActivity : BaseActivity<ActivityMainBinding, MainActivityUiState, Main
     private fun changeBottomNavigationView(id: Int) {
         // TODO 다른 화면들도 정의해야 함.
         when (id) {
-            R.id.homeFragment -> {
+            R.id.homeFragment,
+            R.id.mypageFragment,
+            R.id.activityManagementFragment -> {
                 binding.mainBnv.visibility = View.VISIBLE
-            }
-            R.id.mypageFragment -> {
-                binding.mainBnv.visibility = View.VISIBLE
-
             }
             else -> binding.mainBnv.visibility = View.GONE
         }

--- a/presentation/src/main/java/com/umc/presentation/component/USwitch.kt
+++ b/presentation/src/main/java/com/umc/presentation/component/USwitch.kt
@@ -1,0 +1,264 @@
+package com.umc.presentation.component
+
+import android.animation.ArgbEvaluator
+import android.animation.ValueAnimator
+import android.content.Context
+import android.util.AttributeSet
+import android.view.LayoutInflater
+import android.widget.FrameLayout
+import androidx.core.content.ContextCompat
+import androidx.databinding.BindingAdapter
+import androidx.databinding.InverseBindingAdapter
+import androidx.databinding.InverseBindingListener
+import com.umc.presentation.R
+import com.umc.presentation.databinding.CustomSwitchBinding
+
+class USwitch @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyle: Int = 0,
+) : FrameLayout(context, attrs, defStyle) {
+
+    private val binding = CustomSwitchBinding.inflate(LayoutInflater.from(context), this, true)
+    private val colorEvaluator = ArgbEvaluator()
+
+    private var backgroundColorOn: Int = 0
+    private var backgroundColorOff: Int = 0
+    private var thumbColorOn: Int = 0
+    private var thumbColorOff: Int = 0
+
+    /**
+     * 스위치 관련 상수
+     */
+    private object Constants {
+        const val THUMB_SIZE_ON = 22f
+        const val THUMB_SIZE_OFF = 16f
+        const val TRACK_WIDTH = 52f
+        const val TRACK_HEIGHT = 32f
+        const val STROKE_WIDTH = 2f
+        const val ANIMATION_DURATION = 200L
+    }
+
+    // DP를 PX로 변환
+    private val thumbSizeOnPx by lazy { dpToPx(Constants.THUMB_SIZE_ON) }
+    private val thumbSizeOffPx by lazy { dpToPx(Constants.THUMB_SIZE_OFF) }
+    private val trackWidthPx by lazy { dpToPx(Constants.TRACK_WIDTH) }
+    private val strokeWidthPx by lazy { dpToPx(Constants.STROKE_WIDTH) }
+
+    // Thumb의 마진 계산 (Track 중앙 정렬용)
+    private val marginOff by lazy { dpToPx((Constants.TRACK_HEIGHT - Constants.THUMB_SIZE_OFF) / 2f) }
+    private val marginOn by lazy { dpToPx((Constants.TRACK_HEIGHT - Constants.THUMB_SIZE_ON) / 2f) }
+
+    /**
+     * 스위치의 체크 상태
+     */
+    var isChecked: Boolean = false
+        set(value) {
+            if (field != value) {
+                field = value
+                animateSwitch(value)
+                onCheckedChangeListener?.onCheckedChanged(this, value)
+            }
+        }
+
+    private var onCheckedChangeListener: OnCheckedChangeListener? = null
+
+    init {
+        setupAttributes(attrs, defStyle)
+        // 초기 뷰 상태 업데이트
+        updateVisuals()
+    }
+
+    /**
+     * XML에서 정의한 커스텀 속성 초기화
+     */
+    private fun setupAttributes(attrs: AttributeSet?, defStyle: Int) {
+        isClickable = true
+        isFocusable = true
+
+        val a = context.obtainStyledAttributes(attrs, R.styleable.USwitch, defStyle, 0)
+        try {
+            backgroundColorOn = a.getColor(
+                R.styleable.USwitch_backgroundColorOn,
+                ContextCompat.getColor(context, R.color.primary500)
+            )
+            backgroundColorOff = a.getColor(
+                R.styleable.USwitch_backgroundColorOff,
+                ContextCompat.getColor(context, R.color.neutral100)
+            )
+            thumbColorOn = a.getColor(
+                R.styleable.USwitch_thumbColorOn,
+                ContextCompat.getColor(context, R.color.neutral000)
+            )
+            thumbColorOff = a.getColor(
+                R.styleable.USwitch_thumbColorOff,
+                ContextCompat.getColor(context, R.color.neutral300)
+            )
+            // 초기값 설정 시 애니메이션을 피하기 위해 필드에 직접 접근
+            isChecked = a.getBoolean(R.styleable.USwitch_android_checked, false)
+        } finally {
+            a.recycle()
+        }
+
+        // 클릭 시 상태 반전
+        setOnClickListener { isChecked = !isChecked }
+    }
+
+    /**
+     * On/Off 상태 전환 시 크기, 위치, 색상, 스트로크 변화 애니메이션
+     */
+    private fun animateSwitch(checked: Boolean) {
+        // 크기 변화
+        val (startSize, endSize) = if (checked) {
+            thumbSizeOffPx to thumbSizeOnPx
+        } else {
+            thumbSizeOnPx to thumbSizeOffPx
+        }
+
+        // 위치 변화
+        val maxTranslation = calculateMaxTranslation()
+        val (startTranslation, endTranslation) = if (checked) {
+            marginOff to maxTranslation
+        } else {
+            maxTranslation to marginOff
+        }
+
+        // 테두리 변화
+        val (startStroke, endStroke) = if (checked) {
+            strokeWidthPx to 0f
+        } else {
+            0f to strokeWidthPx
+        }
+
+        ValueAnimator.ofFloat(0f, 1f).apply {
+            duration = Constants.ANIMATION_DURATION
+            addUpdateListener { animator ->
+                val fraction = animator.animatedValue as Float
+                updateThumbSize(startSize, endSize, fraction)
+                updateThumbPosition(startTranslation, endTranslation, fraction)
+                updateStroke(startStroke, endStroke, fraction)
+                updateColors(checked, fraction)
+            }
+            start()
+        }
+    }
+
+    /**
+     * 애니메이션 진행도에 따라 Thumb의 크기를 변경
+     */
+    private fun updateThumbSize(startSize: Float, endSize: Float, fraction: Float) {
+        val currentSize = (startSize + (endSize - startSize) * fraction).toInt()
+        binding.thumb.layoutParams = binding.thumb.layoutParams.apply {
+            width = currentSize
+            height = currentSize
+        }
+        binding.thumb.radius = currentSize / 2f
+    }
+
+    /**
+     * 애니메이션 진행도에 따라 Thumb의 X 좌표를 변경
+     */
+    private fun updateThumbPosition(start: Float, end: Float, fraction: Float) {
+        binding.thumb.translationX = start + (end - start) * fraction
+    }
+
+    /**
+     * 애니메이션 진행도에 따라 Track의 테두리 두께를 변경
+     */
+    private fun updateStroke(start: Float, end: Float, fraction: Float) {
+        val currentStroke = (start + (end - start) * fraction).toInt()
+        binding.track.strokeWidth = currentStroke
+        binding.track.strokeColor = thumbColorOff
+    }
+
+    /**
+     * 애니메이션 진행도에 따라 Track과 Thumb의 색상 변경
+     */
+    private fun updateColors(checked: Boolean, fraction: Float) {
+        val trackColor = colorEvaluator.evaluate(
+            fraction,
+            if (checked) backgroundColorOff else backgroundColorOn,
+            if (checked) backgroundColorOn else backgroundColorOff
+        ) as Int
+
+        val thumbColor = colorEvaluator.evaluate(
+            fraction,
+            if (checked) thumbColorOff else thumbColorOn,
+            if (checked) thumbColorOn else thumbColorOff
+        ) as Int
+
+        binding.track.setCardBackgroundColor(trackColor)
+        binding.thumb.setCardBackgroundColor(thumbColor)
+    }
+
+    /**
+     * Thumb이 이동할 수 있는 최대 X 좌표를 계산
+     */
+    private fun calculateMaxTranslation(): Float {
+        return trackWidthPx - thumbSizeOnPx - marginOn
+    }
+
+    private fun dpToPx(dp: Float): Float {
+        return dp * context.resources.displayMetrics.density
+    }
+
+    /**
+     * 애니메이션 없이 현재 [isChecked] 상태에 맞게 뷰의 외형을 즉시 업데이트
+     */
+    private fun updateVisuals() {
+        val thumbSize = if (isChecked) thumbSizeOnPx else thumbSizeOffPx
+
+        binding.thumb.layoutParams = binding.thumb.layoutParams.apply {
+            width = thumbSize.toInt()
+            height = thumbSize.toInt()
+        }
+        binding.thumb.radius = thumbSize / 2f
+        binding.thumb.translationX = if (isChecked) calculateMaxTranslation() else marginOff
+
+        binding.track.setCardBackgroundColor(
+            if (isChecked) backgroundColorOn else backgroundColorOff
+        )
+        binding.thumb.setCardBackgroundColor(
+            if (isChecked) thumbColorOn else thumbColorOff
+        )
+
+        // 초기 상태가 Off라면 테두리 설정
+        binding.track.strokeWidth = if (isChecked) 0 else strokeWidthPx.toInt()
+        binding.track.strokeColor = thumbColorOff
+    }
+
+    fun setOnCheckedChangeListener(listener: OnCheckedChangeListener?) {
+        onCheckedChangeListener = listener
+    }
+
+    fun interface OnCheckedChangeListener {
+        fun onCheckedChanged(view: USwitch, isChecked: Boolean)
+    }
+
+    /**
+     * Data Binding 및 Two-way Binding 지원을 위한 어댑터 설정
+     */
+    companion object {
+        @JvmStatic
+        @BindingAdapter("android:checked")
+        fun setChecked(view: USwitch, checked: Boolean) {
+            // 무한 루프 방지를 위해 값이 다를 때만 변경
+            if (view.isChecked != checked) {
+                view.isChecked = checked
+            }
+        }
+
+        @JvmStatic
+        @InverseBindingAdapter(attribute = "android:checked")
+        fun isChecked(view: USwitch): Boolean = view.isChecked
+
+        @JvmStatic
+        @BindingAdapter("android:checkedAttrChanged")
+        fun setOnCheckedChangeListener(view: USwitch, listener: InverseBindingListener?) {
+            view.setOnCheckedChangeListener { _, _ ->
+                // 뷰의 상태가 바뀌면 바인딩된 데이터에 알림
+                listener?.onChange()
+            }
+        }
+    }
+}

--- a/presentation/src/main/java/com/umc/presentation/ui/act/ActFragment.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/act/ActFragment.kt
@@ -1,9 +1,6 @@
 package com.umc.presentation.ui.act
 
 import androidx.fragment.app.viewModels
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.lifecycleScope
-import androidx.lifecycle.repeatOnLifecycle
 import com.google.android.material.tabs.TabLayoutMediator
 import com.umc.presentation.R
 import com.umc.presentation.base.BaseFragment
@@ -22,15 +19,19 @@ class ActFragment : BaseFragment<FragmentActBinding, ActViewModel.ActivityManage
 
     override fun initView() {
         binding.vm = viewModel
-        binding.lifecycleOwner = viewLifecycleOwner
+
+        binding.switchAdmin.setOnCheckedChangeListener { _, isChecked ->
+            viewModel.setAdminMode(isChecked)
+        }
     }
 
     override fun initStates() {
         super.initStates()
-        viewLifecycleOwner.lifecycleScope.launch {
-            repeatOnLifecycle(Lifecycle.State.STARTED) {
-                viewModel.isAdminMode.collect { isAdmin ->
-                    setupViewPager(isAdmin)
+        repeatOnStarted(viewLifecycleOwner) {
+            launch {
+                viewModel.uiState.collect { state ->
+                    setupViewPager(state.isAdmin)
+                    // TODO: 그 외 다른 상태 관리
                 }
             }
         }

--- a/presentation/src/main/java/com/umc/presentation/ui/act/ActFragment.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/act/ActFragment.kt
@@ -40,9 +40,13 @@ class ActFragment : BaseFragment<FragmentActBinding, ActViewModel.ActivityManage
     private fun setupViewPager(isAdmin: Boolean) {
         if (currentAdapter?.isAdmin == isAdmin) return
 
+        val currentTabPosition = binding.viewPager.currentItem
+
         val adapter = ActViewPagerAdapter(this, isAdmin)
         currentAdapter = adapter
         binding.viewPager.adapter = adapter
+
+        binding.viewPager.setCurrentItem(currentTabPosition, false)
 
         tabLayoutMediator?.detach()
         tabLayoutMediator = TabLayoutMediator(binding.tabLayout, binding.viewPager) { tab, position ->

--- a/presentation/src/main/java/com/umc/presentation/ui/act/ActFragment.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/act/ActFragment.kt
@@ -1,0 +1,81 @@
+package com.umc.presentation.ui.act
+
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import com.google.android.material.tabs.TabLayoutMediator
+import com.umc.presentation.R
+import com.umc.presentation.base.BaseFragment
+import com.umc.presentation.databinding.FragmentActBinding
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
+
+@AndroidEntryPoint
+class ActFragment : BaseFragment<FragmentActBinding, ActViewModel.ActivityManagementUiState, ActViewModel.ActivityManagementEvent, ActViewModel>(
+    FragmentActBinding::inflate
+) {
+    override val viewModel: ActViewModel by viewModels()
+    private var tabLayoutMediator: TabLayoutMediator? = null
+    private var currentAdapter: ActViewPagerAdapter? = null
+
+    override fun initView() {
+        binding.vm = viewModel
+        binding.lifecycleOwner = viewLifecycleOwner
+
+        binding.switchAdmin.setOnCheckedChangeListener { _, isChecked ->
+            viewModel.switchAdminMode(isChecked)
+        }
+    }
+
+    override fun initStates() {
+        super.initStates()
+        viewLifecycleOwner.lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.isAdminMode.collect { isAdmin ->
+                    setupViewPager(isAdmin)
+                }
+            }
+        }
+    }
+
+    private fun setupViewPager(isAdmin: Boolean) {
+        // 기존 어댑터가 있고 모드가 같으면 재생성하지 않음
+        if (currentAdapter?.isAdmin == isAdmin) {
+            return
+        }
+
+        // 어댑터 설정
+        val adapter = ActViewPagerAdapter(this, isAdmin)
+        currentAdapter = adapter
+        binding.viewPager.adapter = adapter
+
+        // 탭 레이아웃 연결
+        tabLayoutMediator?.detach()
+        tabLayoutMediator = TabLayoutMediator(binding.tabLayout, binding.viewPager) { tab, position ->
+            tab.text = if (isAdmin) {
+                when (position) {
+                    0 -> getString(R.string.tab_attendance_admin)
+                    1 -> getString(R.string.tab_study_admin)
+                    2 -> getString(R.string.tab_challenge_admin)
+                    else -> ""
+                }
+            } else {
+                when (position) {
+                    0 -> getString(R.string.tab_attendance_user)
+                    1 -> getString(R.string.tab_study_user)
+                    2 -> getString(R.string.tab_challenge_user)
+                    else -> ""
+                }
+            }
+        }.apply { attach() }
+    }
+
+    override fun onDestroyView() {
+        tabLayoutMediator?.detach()
+        tabLayoutMediator = null
+        binding.viewPager.adapter = null
+        currentAdapter = null
+        super.onDestroyView()
+    }
+}

--- a/presentation/src/main/java/com/umc/presentation/ui/act/ActFragment.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/act/ActFragment.kt
@@ -22,10 +22,6 @@ class ActFragment : BaseFragment<FragmentActBinding, ActViewModel.ActivityManage
     override fun initView() {
         binding.vm = viewModel
         binding.lifecycleOwner = viewLifecycleOwner
-
-        binding.switchAdmin.setOnCheckedChangeListener { _, isChecked ->
-            viewModel.switchAdminMode(isChecked)
-        }
     }
 
     override fun initStates() {
@@ -40,17 +36,12 @@ class ActFragment : BaseFragment<FragmentActBinding, ActViewModel.ActivityManage
     }
 
     private fun setupViewPager(isAdmin: Boolean) {
-        // 기존 어댑터가 있고 모드가 같으면 재생성하지 않음
-        if (currentAdapter?.isAdmin == isAdmin) {
-            return
-        }
+        if (currentAdapter?.isAdmin == isAdmin) return
 
-        // 어댑터 설정
         val adapter = ActViewPagerAdapter(this, isAdmin)
         currentAdapter = adapter
         binding.viewPager.adapter = adapter
 
-        // 탭 레이아웃 연결
         tabLayoutMediator?.detach()
         tabLayoutMediator = TabLayoutMediator(binding.tabLayout, binding.viewPager) { tab, position ->
             tab.text = if (isAdmin) {

--- a/presentation/src/main/java/com/umc/presentation/ui/act/ActFragment.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/act/ActFragment.kt
@@ -8,6 +8,7 @@ import com.google.android.material.tabs.TabLayoutMediator
 import com.umc.presentation.R
 import com.umc.presentation.base.BaseFragment
 import com.umc.presentation.databinding.FragmentActBinding
+import com.umc.presentation.ui.act.adapter.ActViewPagerAdapter
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 

--- a/presentation/src/main/java/com/umc/presentation/ui/act/ActViewModel.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/act/ActViewModel.kt
@@ -12,13 +12,8 @@ import javax.inject.Inject
 class ActViewModel @Inject constructor() : BaseViewModel<ActViewModel.ActivityManagementUiState, ActViewModel.ActivityManagementEvent>(
     ActivityManagementUiState()
 ) {
-    private val _isAdminMode = MutableStateFlow(false)
-    val isAdminMode = _isAdminMode.asStateFlow()
+    val isAdminMode = MutableStateFlow(false)
 
-    fun switchAdminMode(isChecked: Boolean) {
-        _isAdminMode.value = isChecked
-    }
-    
     data class ActivityManagementUiState(val temp: String = "") : UiState
     sealed class ActivityManagementEvent : UiEvent
 }

--- a/presentation/src/main/java/com/umc/presentation/ui/act/ActViewModel.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/act/ActViewModel.kt
@@ -4,16 +4,20 @@ import com.umc.presentation.base.BaseViewModel
 import com.umc.presentation.base.UiEvent
 import com.umc.presentation.base.UiState
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.asStateFlow
 import javax.inject.Inject
 
 @HiltViewModel
 class ActViewModel @Inject constructor() : BaseViewModel<ActViewModel.ActivityManagementUiState, ActViewModel.ActivityManagementEvent>(
     ActivityManagementUiState()
 ) {
-    val isAdminMode = MutableStateFlow(false)
+    data class ActivityManagementUiState(
+        val isAdmin: Boolean = false,
+        val temp: String = ""
+    ) : UiState
 
-    data class ActivityManagementUiState(val temp: String = "") : UiState
     sealed class ActivityManagementEvent : UiEvent
+
+    fun setAdminMode(isAdmin: Boolean) {
+        updateState { copy(isAdmin = isAdmin) }
+    }
 }

--- a/presentation/src/main/java/com/umc/presentation/ui/act/ActViewModel.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/act/ActViewModel.kt
@@ -1,0 +1,24 @@
+package com.umc.presentation.ui.act
+
+import com.umc.presentation.base.BaseViewModel
+import com.umc.presentation.base.UiEvent
+import com.umc.presentation.base.UiState
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import javax.inject.Inject
+
+@HiltViewModel
+class ActViewModel @Inject constructor() : BaseViewModel<ActViewModel.ActivityManagementUiState, ActViewModel.ActivityManagementEvent>(
+    ActivityManagementUiState()
+) {
+    private val _isAdminMode = MutableStateFlow(false)
+    val isAdminMode = _isAdminMode.asStateFlow()
+
+    fun switchAdminMode(isChecked: Boolean) {
+        _isAdminMode.value = isChecked
+    }
+    
+    data class ActivityManagementUiState(val temp: String = "") : UiState
+    sealed class ActivityManagementEvent : UiEvent
+}

--- a/presentation/src/main/java/com/umc/presentation/ui/act/ActViewPagerAdapter.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/act/ActViewPagerAdapter.kt
@@ -1,0 +1,45 @@
+package com.umc.presentation.ui.act
+
+import androidx.fragment.app.Fragment
+import androidx.viewpager2.adapter.FragmentStateAdapter
+import com.umc.presentation.ui.act.challenge.AdminChallengeFragment
+import com.umc.presentation.ui.act.challenge.UserChallengerFragment
+import com.umc.presentation.ui.act.check.AdminCheckFragment
+import com.umc.presentation.ui.act.check.UserCheckFragment
+import com.umc.presentation.ui.act.study.AdminStudyFragment
+import com.umc.presentation.ui.act.study.UserStudyFragment
+
+class ActViewPagerAdapter(
+    fragment: Fragment,
+    val isAdmin: Boolean
+) : FragmentStateAdapter(fragment) {
+
+    companion object {
+        private const val TAB_COUNT = 3
+
+        // 탭 위치 상수
+        const val TAB_CHECK = 0
+        const val TAB_STUDY = 1
+        const val TAB_CHALLENGE = 2
+    }
+
+    override fun getItemCount(): Int = TAB_COUNT
+
+    override fun createFragment(position: Int): Fragment {
+        return if (isAdmin) {
+            when (position) {
+                TAB_CHECK -> AdminCheckFragment()
+                TAB_STUDY -> AdminStudyFragment()
+                TAB_CHALLENGE -> AdminChallengeFragment()
+                else -> throw IllegalStateException("Invalid position: $position")
+            }
+        } else {
+            when (position) {
+                TAB_CHECK -> UserCheckFragment()
+                TAB_STUDY -> UserStudyFragment()
+                TAB_CHALLENGE -> UserChallengerFragment()
+                else -> throw IllegalStateException("Invalid position: $position")
+            }
+        }
+    }
+}

--- a/presentation/src/main/java/com/umc/presentation/ui/act/adapter/ActViewPagerAdapter.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/act/adapter/ActViewPagerAdapter.kt
@@ -1,4 +1,4 @@
-package com.umc.presentation.ui.act
+package com.umc.presentation.ui.act.adapter
 
 import androidx.fragment.app.Fragment
 import androidx.viewpager2.adapter.FragmentStateAdapter

--- a/presentation/src/main/java/com/umc/presentation/ui/act/challenge/AdminChallengeFragment.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/act/challenge/AdminChallengeFragment.kt
@@ -1,0 +1,14 @@
+package com.umc.presentation.ui.act.challenge
+
+import com.umc.presentation.base.BaseFragment
+import com.umc.presentation.databinding.FragmentAdminChallengeBinding
+
+class AdminChallengeFragment : BaseFragment<FragmentAdminChallengeBinding, Nothing, Nothing, Nothing>(
+    FragmentAdminChallengeBinding::inflate
+) {
+    override val viewModel: Nothing
+        get() = throw IllegalStateException("ViewModel is not used in this Fragment.")
+
+    override fun initView() {}
+    override fun initStates() {}
+}

--- a/presentation/src/main/java/com/umc/presentation/ui/act/challenge/UserChallengerFragment.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/act/challenge/UserChallengerFragment.kt
@@ -1,0 +1,14 @@
+package com.umc.presentation.ui.act.challenge
+
+import com.umc.presentation.base.BaseFragment
+import com.umc.presentation.databinding.FragmentUserChallengeBinding
+
+class UserChallengerFragment : BaseFragment<FragmentUserChallengeBinding, Nothing, Nothing, Nothing>(
+    FragmentUserChallengeBinding::inflate
+) {
+    override val viewModel: Nothing
+        get() = throw IllegalStateException("ViewModel is not used in this Fragment.")
+
+    override fun initView() {}
+    override fun initStates() {}
+}

--- a/presentation/src/main/java/com/umc/presentation/ui/act/check/AdminCheckFragment.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/act/check/AdminCheckFragment.kt
@@ -1,0 +1,14 @@
+package com.umc.presentation.ui.act.check
+
+import com.umc.presentation.base.BaseFragment
+import com.umc.presentation.databinding.FragmentAdminCheckBinding
+
+class AdminCheckFragment : BaseFragment<FragmentAdminCheckBinding, Nothing, Nothing, Nothing>(
+    FragmentAdminCheckBinding::inflate
+) {
+    override val viewModel: Nothing
+        get() = throw IllegalStateException("ViewModel is not used in this Fragment.")
+
+    override fun initView() {}
+    override fun initStates() {}
+}

--- a/presentation/src/main/java/com/umc/presentation/ui/act/check/UserCheckFragment.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/act/check/UserCheckFragment.kt
@@ -1,0 +1,14 @@
+package com.umc.presentation.ui.act.check
+
+import com.umc.presentation.base.BaseFragment
+import com.umc.presentation.databinding.FragmentUserCheckBinding
+
+class UserCheckFragment : BaseFragment<FragmentUserCheckBinding, Nothing, Nothing, Nothing>(
+    FragmentUserCheckBinding::inflate
+) {
+    override val viewModel: Nothing
+        get() = throw IllegalStateException("ViewModel is not used in this Fragment.")
+
+    override fun initView() {}
+    override fun initStates() {}
+}

--- a/presentation/src/main/java/com/umc/presentation/ui/act/study/AdminStudyFragment.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/act/study/AdminStudyFragment.kt
@@ -1,0 +1,14 @@
+package com.umc.presentation.ui.act.study
+
+import com.umc.presentation.base.BaseFragment
+import com.umc.presentation.databinding.FragmentAdminStudyBinding
+
+class AdminStudyFragment : BaseFragment<FragmentAdminStudyBinding, Nothing, Nothing, Nothing>(
+    FragmentAdminStudyBinding::inflate
+) {
+    override val viewModel: Nothing
+        get() = throw IllegalStateException("ViewModel is not used in this Fragment.")
+
+    override fun initView() {}
+    override fun initStates() {}
+}

--- a/presentation/src/main/java/com/umc/presentation/ui/act/study/UserStudyFragment.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/act/study/UserStudyFragment.kt
@@ -1,0 +1,14 @@
+package com.umc.presentation.ui.act.study
+
+import com.umc.presentation.base.BaseFragment
+import com.umc.presentation.databinding.FragmentUserStudyBinding
+
+class UserStudyFragment : BaseFragment<FragmentUserStudyBinding, Nothing, Nothing, Nothing>(
+    FragmentUserStudyBinding::inflate
+) {
+    override val viewModel: Nothing
+        get() = throw IllegalStateException("ViewModel is not used in this Fragment.")
+
+    override fun initView() {}
+    override fun initStates() {}
+}

--- a/presentation/src/main/res/drawable/switch_thumb_selector.xml
+++ b/presentation/src/main/res/drawable/switch_thumb_selector.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_checked="true">
+        <shape android:shape="oval">
+            <solid android:color="@color/neutral000" />
+            <size android:width="23dp" android:height="23dp"/>
+        </shape>
+    </item>
+    <item android:state_checked="false">
+        <shape android:shape="oval">
+            <solid android:color="@color/neutral300" />
+            <size android:width="16dp" android:height="16dp"/>
+        </shape>
+    </item>
+</selector>

--- a/presentation/src/main/res/drawable/switch_track_selector.xml
+++ b/presentation/src/main/res/drawable/switch_track_selector.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_checked="true">
+        <shape android:shape="rectangle">
+            <solid android:color="@color/primary500" />
+            <corners android:radius="100dp" />
+        </shape>
+    </item>
+    <item android:state_checked="false">
+        <shape android:shape="rectangle">
+            <solid android:color="@color/neutral300" />
+            <corners android:radius="100dp" />
+        </shape>
+    </item>
+</selector>

--- a/presentation/src/main/res/drawable/tap_indicator_rect.xml
+++ b/presentation/src/main/res/drawable/tap_indicator_rect.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/neutral800" />
+    <corners android:radius="0dp" />
+</shape>

--- a/presentation/src/main/res/layout/custom_switch.xml
+++ b/presentation/src/main/res/layout/custom_switch.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="51dp"
+    android:layout_height="31dp">
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/track"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:cardCornerRadius="15.5dp"
+        app:cardElevation="0dp"
+        app:strokeWidth="2dp"
+        app:strokeColor="@color/neutral300"/>
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/thumb"
+        android:layout_width="16dp"
+        android:layout_height="16dp"
+        android:layout_gravity="start|center_vertical"
+        android:layout_marginStart="0dp"
+        app:cardCornerRadius="8dp"
+        app:cardElevation="0dp"
+        app:strokeWidth="0dp"/>
+
+</FrameLayout>

--- a/presentation/src/main/res/layout/fragment_act.xml
+++ b/presentation/src/main/res/layout/fragment_act.xml
@@ -50,7 +50,7 @@
                 android:id="@+id/switch_admin"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:checked="@{vm.isAdminMode}" />
+                android:checked="@={vm.isAdminMode}" />
 
         </LinearLayout>
 

--- a/presentation/src/main/res/layout/fragment_act.xml
+++ b/presentation/src/main/res/layout/fragment_act.xml
@@ -50,7 +50,7 @@
                 android:id="@+id/switch_admin"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:checked="@={vm.isAdminMode}" />
+                android:checked="@{vm.uiState.isAdmin}" />
 
         </LinearLayout>
 

--- a/presentation/src/main/res/layout/fragment_act.xml
+++ b/presentation/src/main/res/layout/fragment_act.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+        <variable
+            name="vm"
+            type="com.umc.presentation.ui.act.ActViewModel" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@color/neutral000"
+        tools:context=".ui.act.ActFragment">
+
+        <!-- Header Section -->
+        <LinearLayout
+            android:id="@+id/header_layout"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:padding="16dp"
+            android:layout_marginTop="56dp"
+            android:gravity="center_vertical"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent">
+
+            <TextView
+                android:id="@+id/tv_title"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="@string/activity_management_title"
+                android:textColor="@color/neutral800"
+                style="@style/Title2Bold" />
+
+            <TextView
+                android:id="@+id/tv_admin_label"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/admin_label"
+                android:textColor="@color/neutral600"
+                android:layout_marginEnd="8dp"
+                style="@style/Subheadline" />
+
+            <com.umc.presentation.component.USwitch
+                android:id="@+id/switch_admin"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:checked="@{vm.isAdminMode}" />
+
+        </LinearLayout>
+
+        <!-- Tab Layout -->
+        <com.google.android.material.tabs.TabLayout
+            android:id="@+id/tab_layout"
+            android:layout_width="0dp"
+            android:layout_height="55dp"
+            android:background="@color/neutral000"
+            app:tabMode="fixed"
+            app:tabGravity="fill"
+            app:tabIndicator="@drawable/tap_indicator_rect"
+            app:tabIndicatorHeight="2dp"
+            app:tabIndicatorFullWidth="true"
+            app:tabIndicatorColor="@color/neutral800"
+            app:tabSelectedTextColor="@color/neutral800"
+            app:tabTextColor="@color/neutral400"
+            app:tabTextAppearance="@style/SubheadlineBold"
+            app:tabRippleColor="@android:color/transparent"
+            app:layout_constraintTop_toBottomOf="@+id/header_layout"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent" />
+
+        <!-- ViewPager2 -->
+        <androidx.viewpager2.widget.ViewPager2
+            android:id="@+id/view_pager"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:background="?attr/colorBackgroundSemantic"
+            app:layout_constraintTop_toBottomOf="@+id/tab_layout"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/presentation/src/main/res/layout/fragment_admin_challenge.xml
+++ b/presentation/src/main/res/layout/fragment_admin_challenge.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android">
+    <data></data>
+    <FrameLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Admin Challenge Fragment" />
+    </FrameLayout>
+</layout>

--- a/presentation/src/main/res/layout/fragment_admin_check.xml
+++ b/presentation/src/main/res/layout/fragment_admin_check.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android">
+    <data></data>
+    <FrameLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Admin Check Fragment" />
+    </FrameLayout>
+</layout>

--- a/presentation/src/main/res/layout/fragment_admin_study.xml
+++ b/presentation/src/main/res/layout/fragment_admin_study.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android">
+    <data></data>
+    <FrameLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Admin Study Fragment" />
+    </FrameLayout>
+</layout>

--- a/presentation/src/main/res/layout/fragment_user_challenge.xml
+++ b/presentation/src/main/res/layout/fragment_user_challenge.xml
@@ -3,7 +3,7 @@
     <data></data>
     <FrameLayout
         android:layout_width="match_parent"
-        android.layout_height="match_parent">
+        android:layout_height="match_parent">
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/presentation/src/main/res/layout/fragment_user_challenge.xml
+++ b/presentation/src/main/res/layout/fragment_user_challenge.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android">
+    <data></data>
+    <FrameLayout
+        android:layout_width="match_parent"
+        android.layout_height="match_parent">
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="User Challenge Fragment" />
+    </FrameLayout>
+</layout>

--- a/presentation/src/main/res/layout/fragment_user_check.xml
+++ b/presentation/src/main/res/layout/fragment_user_check.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android">
+    <data></data>
+    <FrameLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="User Check Fragment" />
+    </FrameLayout>
+</layout>

--- a/presentation/src/main/res/layout/fragment_user_study.xml
+++ b/presentation/src/main/res/layout/fragment_user_study.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android">
+    <data></data>
+    <FrameLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="User Study Fragment" />
+    </FrameLayout>
+</layout>

--- a/presentation/src/main/res/navigation/nav_act.xml
+++ b/presentation/src/main/res/navigation/nav_act.xml
@@ -1,6 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <navigation xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:id="@+id/nav_act">
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/nav_act"
+    app:startDestination="@id/activityManagementFragment">
+
+    <fragment
+        android:id="@+id/activityManagementFragment"
+        android:name="com.umc.presentation.ui.act.ActFragment"
+        android:label="활동 관리 화면"
+        tools:layout="@layout/fragment_act" />
 
 </navigation>

--- a/presentation/src/main/res/values/attrs.xml
+++ b/presentation/src/main/res/values/attrs.xml
@@ -55,6 +55,13 @@
     </declare-styleable>
 
 
-    <!-- 공통 Tag -->
+    <!-- 공통 Switch -->
+    <declare-styleable name="USwitch">
+        <attr name="android:checked" />
+        <attr name="backgroundColorOn" format="color" />
+        <attr name="backgroundColorOff" format="color" />
+        <attr name="thumbColorOn" format="color" />
+        <attr name="thumbColorOff" format="color" />
+    </declare-styleable>
 
 </resources>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -23,4 +23,16 @@
     <string name="sign_up_nickname_placeholder">활동할 닉네임을 입력하세요</string>
     <string name="sign_up_email_placeholder">example@univ.ac.kr</string>
     <string name="sign_up_verify_request">인증 요청</string>
+
+    <!-- Activity -->
+    <string name="activity_management_title">활동 관리</string>
+    <string name="admin_label">Admin</string>
+
+    <string name="tab_attendance_user">출석 체크</string>
+    <string name="tab_study_user">스터디/활동</string>
+    <string name="tab_challenge_user">챌린저</string>
+
+    <string name="tab_attendance_admin">출석 관리</string>
+    <string name="tab_study_admin">스터디 관리</string>
+    <string name="tab_challenge_admin">챌린저 관리</string>
 </resources>


### PR DESCRIPTION
## #️⃣ 이슈 번호

> 관련된 이슈 번호를 적어주세요.\
> Close #16 

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 요약해주세요.

활동 관리 화면의 전반적인 UI 구조를 설계하고, 스위치 컴포넌트와 모드 전환 로직을 구현했습니다.
- 커스텀 `USwitch` 컴포넌트 구현: `ArgbEvaluator`와 `ValueAnimator`를 사용하여 On/Off 전환 시 크기, 위치, 색상이 부드럽게 변하는 애니메이션 토글을 구현했습니다.
- 활동 관리 메인 화면(`ActFragment`) 구성: `TabLayout`과 `ViewPager2`를 통해 출석, 스터디, 챌린저 탭 구조를 설계했습니다.
- 동적 어댑터(`ActViewPagerAdapter`) 설계: `isAdmin` 상태 값에 따라 각 탭에 들어갈 프래그먼트를 동적으로 생성하도록 구현했습니다.
- 탭별 초기 프래그먼트 생성: 출석, 스터디, 챌린저 각 기능에 대응하는 챌린저용/운영진용 프래그먼트 6개를 초기화했습니다.

## 📸 스크린샷 (선택 사항)
| 설명 | 이미지 |
| :---: | :---: |
| **챌린저용 활동 화면** | <img width="300" alt="image" src="https://github.com/user-attachments/assets/1e62a57d-c015-4f30-8326-4bf116a0127f" /> |
| **운영진용 활동 화면** | <img width="300" alt="image" src="https://github.com/user-attachments/assets/4aa13bef-7fe0-4cb3-936a-2a1e5bc44a3f" /> |
> 상단 여백을 준 게 상태바 뒤까지 채우도록 하는 의도인 거 같아서 MainActivity에 enableToEdge()를 추가했는데 그게 아니라면 다시 빼도록 하겠습니다...

## 🚩 리뷰 요구사항
> 리뷰어가 중점적으로 봐주었으면 하는 부분이 있다면 작성해주세요.
- 프로젝트 구조에 맞추어 잘 작성되었는지 확인 부탁드립니다.
- 활동 탭 안에 필요한 프래그먼트가 많아서 act 내에서 기능에 따라 패키지를 또 나누고 챌린저와 어드민에 따라 프래그먼트를 만들 때 앞에 User, Admin을 붙였는데 (챌린저를 쓰면 너무 길어지는 거 같아서..) 적합한 네이밍 방식이 있다면 말씀해주시면 감사하겠습니다!

## 🏁 체크리스트
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 로그나 주석을 제거했나요?
- [x] 머지 대상 브랜치(Base branch)가 올바른가요?
