### PR TITLE
[Feat/#27] 스터디 UI구성

### DIFF
--- a/presentation/src/main/java/com/umc/presentation/ui/act/study/ActStudyAdapter.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/act/study/ActStudyAdapter.kt
@@ -1,0 +1,139 @@
+package com.umc.presentation.ui.act.study
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.umc.presentation.databinding.ItemActStudyBinding
+import androidx.core.content.ContextCompat
+import com.umc.presentation.R
+
+
+class ActStudyAdapter(
+    private val onToggle: (Int) -> Unit,
+    private val onLongApprove: (Long) -> Unit,
+    private val onSubmitClick: (Long, String) -> Unit,
+) : ListAdapter<ActStudyItemUiModel, ActStudyAdapter.VH>(DIFF) {
+
+    companion object {
+        private val DIFF = object : DiffUtil.ItemCallback<ActStudyItemUiModel>() {
+            override fun areItemsTheSame(old: ActStudyItemUiModel, new: ActStudyItemUiModel) =
+                old.id == new.id
+
+            override fun areContentsTheSame(old: ActStudyItemUiModel, new: ActStudyItemUiModel) =
+                old == new
+        }
+    }
+
+
+    private val draftLinks = mutableMapOf<Long, String>()
+
+    init {
+        setHasStableIds(true)
+    }
+
+    override fun getItemId(position: Int): Long = getItem(position).id
+
+    fun updateDraftLink(itemId: Long, link: String) {
+        draftLinks[itemId] = link
+    }
+
+    inner class VH(private val binding: ItemActStudyBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+
+        private var currentItemId: Long = -1L
+
+        private fun updateSubmitButtonUi(link: String) {
+            val enabled = link.isNotBlank()
+
+            binding.btnSubmit.isEnabled = enabled
+
+            if (enabled) {
+                binding.btnSubmit.setText("링크 제출하기")
+                binding.btnSubmit.setTextColor(
+                    ContextCompat.getColor(binding.root.context, R.color.neutral000)
+                )
+                binding.btnSubmit.setUBackgroundColor(
+                    ContextCompat.getColor(binding.root.context, R.color.primary500)
+                )
+            } else {
+                binding.btnSubmit.setText("링크 제출하기")
+                binding.btnSubmit.setTextColor(
+                    ContextCompat.getColor(binding.root.context, R.color.neutral500)
+                )
+                binding.btnSubmit.setUBackgroundColor(
+                    ContextCompat.getColor(binding.root.context, R.color.neutral200)
+                )
+            }
+        }
+
+        init {
+
+
+            binding.root.setOnClickListener {
+                val pos = bindingAdapterPosition
+                if (pos != RecyclerView.NO_POSITION) onToggle(pos)
+            }
+            binding.ivArrow.setOnClickListener {
+                val pos = bindingAdapterPosition
+                if (pos != RecyclerView.NO_POSITION) onToggle(pos)
+            }
+
+
+            binding.etLink.setOnTextChangedListener { text ->
+                if (currentItemId != -1L) {
+                    draftLinks[currentItemId] = text
+                    updateSubmitButtonUi(text)
+                }
+            }
+
+
+            binding.btnSubmit.setOnClickListener {
+                if (currentItemId == -1L) return@setOnClickListener
+                val link = draftLinks[currentItemId] ?: binding.etLink.getText()
+                onSubmitClick(currentItemId, link)
+            }
+
+            binding.btnConfirm.setOnClickListener {
+                if (currentItemId == -1L) return@setOnClickListener
+                val link = draftLinks[currentItemId] ?: binding.etLink.getText()
+                onSubmitClick(currentItemId, link)
+            }
+
+            binding.btnStatus.setOnLongClickListener {
+                if (currentItemId != -1L) onLongApprove(currentItemId)
+                true
+            }
+
+
+        }
+
+
+        fun bind(item: ActStudyItemUiModel) {
+            currentItemId = item.id
+            binding.item = item
+
+
+            val currentLink = draftLinks[item.id] ?: item.link
+
+
+            if (currentLink != binding.etLink.getText()) {
+                binding.etLink.setText(currentLink)
+            }
+
+
+            updateSubmitButtonUi(currentLink)
+
+            binding.executePendingBindings()
+        }
+
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): VH {
+        val binding = ItemActStudyBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return VH(binding)
+    }
+
+    override fun onBindViewHolder(holder: VH, position: Int) = holder.bind(getItem(position))
+}

--- a/presentation/src/main/java/com/umc/presentation/ui/act/study/ActStudyBindingAdapters.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/act/study/ActStudyBindingAdapters.kt
@@ -1,0 +1,79 @@
+package com.umc.presentation.ui.act.study
+
+import android.view.View
+import android.widget.ImageView
+import android.widget.TextView
+import androidx.core.content.ContextCompat
+import androidx.databinding.BindingAdapter
+import com.umc.presentation.R
+import com.umc.presentation.component.UButton
+
+@BindingAdapter("submitButtonStyle")
+fun UButton.bindSubmitButtonStyle(status: StudyStatus?) {
+    if (status == null) return
+
+
+    val (bgRes, textRes) = when (status) {
+        StudyStatus.PASS -> R.color.neutral100 to R.color.neutral500
+        StudyStatus.FAIL -> R.color.warning500 to R.color.neutral000
+        StudyStatus.IN_PROGRESS -> R.color.primary500 to R.color.neutral000
+    }
+
+
+    setUBackgroundColor(ContextCompat.getColor(context, bgRes))
+    setTextColor(ContextCompat.getColor(context, textRes))
+
+
+    isEnabled = status != StudyStatus.PASS
+    alpha = if (status == StudyStatus.PASS) 0.6f else 1f
+}
+
+@BindingAdapter("confirmButtonStyle")
+fun UButton.bindConfirmButtonStyle(isConfirming: Boolean) {
+    if (!isConfirming) return
+
+    setUBackgroundColor(
+        ContextCompat.getColor(context, R.color.primary500)
+    )
+    setTextColor(
+        ContextCompat.getColor(context, R.color.neutral000)
+    )
+    isEnabled = true
+    alpha = 1f
+}
+
+@BindingAdapter("timelineStatus", "timelineWeek", requireAll = false)
+fun bindTimelineStatus(
+    view: View,
+    status: StudyStatus?,
+    week: Int?
+) {
+    val root = view as? androidx.constraintlayout.widget.ConstraintLayout ?: return
+
+    val iv = root.findViewById<ImageView>(R.id.iv_timeline_status)
+    val tv = root.findViewById<TextView>(R.id.tv_timeline_number)
+
+    if (status == null) return
+
+    when (status) {
+        StudyStatus.PASS -> {
+            iv.visibility = View.VISIBLE
+            tv.visibility = View.GONE
+            iv.setImageResource(R.drawable.ic_check_success)
+        }
+
+        StudyStatus.FAIL -> {
+            iv.visibility = View.VISIBLE
+            tv.visibility = View.GONE
+            iv.setImageResource(R.drawable.ic_check_failed)
+        }
+
+        StudyStatus.IN_PROGRESS -> {
+            iv.visibility = View.GONE
+            tv.visibility = View.VISIBLE
+            tv.text = (week ?: 0).toString()
+            tv.background = ContextCompat.getDrawable(root.context, R.drawable.bg_primary500_circle)
+        }
+    }
+}
+

--- a/presentation/src/main/java/com/umc/presentation/ui/act/study/ActStudyItemUiModel.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/act/study/ActStudyItemUiModel.kt
@@ -1,0 +1,12 @@
+package com.umc.presentation.ui.act.study
+
+data class ActStudyItemUiModel(
+    val id: Long,
+    val platform: String,
+    val title: String,
+    val status: StudyStatus,
+    val week: Int = id.toInt(),
+    val isExpanded: Boolean = false,
+    val link: String = "",
+    val submitState: SubmitState = SubmitState.IDLE,
+)

--- a/presentation/src/main/java/com/umc/presentation/ui/act/study/StudyBindingAdapters.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/act/study/StudyBindingAdapters.kt
@@ -1,0 +1,64 @@
+package com.umc.presentation.ui.act.study
+
+
+import androidx.core.content.ContextCompat
+import androidx.databinding.BindingAdapter
+import com.umc.presentation.R
+import com.umc.presentation.component.UButton
+import android.view.View
+
+
+@BindingAdapter("studyStatusStyle")
+fun UButton.bindStudyStatusStyle(status: StudyStatus?) {
+    if (status == null) return
+
+
+    setText(status.text)
+
+
+    val (bgRes, textRes) = when (status) {
+        StudyStatus.PASS -> R.color.success100 to R.color.success700
+        StudyStatus.FAIL -> R.color.danger100 to R.color.danger700
+        StudyStatus.IN_PROGRESS -> R.color.primary100 to R.color.primary600
+    }
+
+    setTextColor(ContextCompat.getColor(context, textRes))
+    setUBackgroundColor(ContextCompat.getColor(context, bgRes))
+}
+
+@BindingAdapter("visibleWhenInput")
+fun View.visibleWhenInput(item: ActStudyItemUiModel?) {
+    if (item == null) return
+    visibility =
+        if (
+            item.status == StudyStatus.IN_PROGRESS &&
+            (item.submitState == SubmitState.IDLE || item.submitState == SubmitState.READY)
+        ) View.VISIBLE else View.GONE
+}
+
+
+@BindingAdapter("visibleWhenConfirming")
+fun View.visibleWhenConfirming(item: ActStudyItemUiModel?) {
+    if (item == null) return
+    visibility = if (item.submitState == SubmitState.CONFIRMING) View.VISIBLE else View.GONE
+}
+
+@BindingAdapter("visibleWhenWaiting")
+fun View.visibleWhenWaiting(item: ActStudyItemUiModel?) {
+    if (item == null) return
+    visibility =
+        if (item.status == StudyStatus.IN_PROGRESS && item.submitState == SubmitState.REQUESTED)
+            View.VISIBLE else View.GONE
+}
+
+@BindingAdapter("visibleWhenResultPass")
+fun View.visibleWhenResultPass(item: ActStudyItemUiModel?) {
+    if (item == null) return
+    visibility = if (item.status == StudyStatus.PASS) View.VISIBLE else View.GONE
+}
+
+@BindingAdapter("visibleWhenResultFail")
+fun View.visibleWhenResultFail(item: ActStudyItemUiModel?) {
+    if (item == null) return
+    visibility = if (item.status == StudyStatus.FAIL) View.VISIBLE else View.GONE
+}

--- a/presentation/src/main/java/com/umc/presentation/ui/act/study/StudyStatus.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/act/study/StudyStatus.kt
@@ -1,0 +1,7 @@
+package com.umc.presentation.ui.act.study
+
+enum class StudyStatus(val text: String) {
+    PASS("Pass"),
+    FAIL("Fail"),
+    IN_PROGRESS("In Progress"),
+}

--- a/presentation/src/main/java/com/umc/presentation/ui/act/study/SubmitState.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/act/study/SubmitState.kt
@@ -1,0 +1,8 @@
+package com.umc.presentation.ui.act.study
+
+enum class SubmitState {
+    IDLE,
+    READY,
+    CONFIRMING,
+    REQUESTED
+}

--- a/presentation/src/main/java/com/umc/presentation/ui/act/study/UserStudyFragment.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/act/study/UserStudyFragment.kt
@@ -1,14 +1,46 @@
 package com.umc.presentation.ui.act.study
 
+import androidx.fragment.app.viewModels
+import androidx.recyclerview.widget.LinearLayoutManager
 import com.umc.presentation.base.BaseFragment
 import com.umc.presentation.databinding.FragmentUserStudyBinding
 
-class UserStudyFragment : BaseFragment<FragmentUserStudyBinding, Nothing, Nothing, Nothing>(
-    FragmentUserStudyBinding::inflate
+class UserStudyFragment : BaseFragment<FragmentUserStudyBinding, UserStudyState, UserStudyEvent, UserStudyViewModel>(
+    FragmentUserStudyBinding::inflate,
 ) {
-    override val viewModel: Nothing
-        get() = throw IllegalStateException("ViewModel is not used in this Fragment.")
+    override val viewModel: UserStudyViewModel by viewModels()
 
-    override fun initView() {}
-    override fun initStates() {}
+    private lateinit var adapter: ActStudyAdapter
+
+    override fun initView() {
+        adapter = ActStudyAdapter(
+            onToggle = { index -> viewModel.toggleExpand(index) },
+            onLongApprove = { itemId -> viewModel.debugApprove(itemId) },
+            onSubmitClick = { itemId, link -> viewModel.onSubmitClick(itemId, link) },
+        )
+
+
+
+        binding.rvUserStudy.layoutManager = LinearLayoutManager(requireContext())
+        binding.rvUserStudy.adapter = adapter
+        binding.state = viewModel.uiState.value   
+        binding.lifecycleOwner = viewLifecycleOwner
+
+    }
+
+    override fun initStates() {
+        repeatOnStarted(viewLifecycleOwner) {
+            viewModel.uiState.collect { state ->
+
+                binding.tvPart.text = "WEB PART CURRICULUM"
+                binding.tvTitle.text = state.title
+                binding.tvPercent.text = state.percentText
+                binding.progress.progress = state.progress
+                binding.tvSub.text = state.subText
+
+
+                adapter.submitList(state.items)
+            }
+        }
+    }
 }

--- a/presentation/src/main/java/com/umc/presentation/ui/act/study/UserStudyViewModel.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/act/study/UserStudyViewModel.kt
@@ -1,0 +1,91 @@
+package com.umc.presentation.ui.act.study
+
+import com.umc.presentation.base.BaseViewModel
+import com.umc.presentation.base.UiEvent
+import com.umc.presentation.base.UiState
+import com.umc.presentation.ui.act.study.ActStudyItemUiModel
+
+
+
+data class UserStudyState(
+    val title: String = "웹 프론트엔드 기초",
+    val items: List<ActStudyItemUiModel> = emptyList(),
+) : UiState {
+
+    val totalCount: Int get() = items.size
+    val passCount: Int get() = items.count { it.status == StudyStatus.PASS }
+
+    val progress: Int
+        get() = if (totalCount == 0) 0 else (passCount * 100 / totalCount)
+
+    val percentText: String get() = "$progress%"
+
+    val subText: String get() = "${passCount}/${totalCount} 완료"
+}
+
+
+sealed interface UserStudyEvent : UiEvent
+
+class UserStudyViewModel : BaseViewModel<UserStudyState, UserStudyEvent>(
+    UserStudyState(
+        items = listOf(
+            ActStudyItemUiModel(1, "Github", "HTML/CSS 기초", StudyStatus.PASS),
+            ActStudyItemUiModel(2, "Github", "HTML/CSS 기초", StudyStatus.FAIL),
+            ActStudyItemUiModel(3, "Github", "HTML/CSS 기초", StudyStatus.IN_PROGRESS),
+
+        )
+    )
+) {
+
+    fun toggleExpand(index: Int) {
+        updateState {
+            copy(
+                items = items.mapIndexed { i, item ->
+                    if (i == index) item.copy(isExpanded = !item.isExpanded) else item
+                }
+            )
+        }
+    }
+
+    fun onSubmitClick(itemId: Long, link: String) {
+        updateItem(itemId) { item ->
+            when (item.submitState) {
+                SubmitState.REQUESTED -> item
+
+                SubmitState.CONFIRMING -> item.copy(
+                    submitState = SubmitState.REQUESTED
+                )
+
+                SubmitState.IDLE,
+                SubmitState.READY -> {
+                    if (link.isBlank()) item
+                    else item.copy(
+                        link = link,
+                        submitState = SubmitState.CONFIRMING
+                    )
+                }
+            }
+        }
+    }
+
+
+
+    fun debugApprove(itemId: Long) {
+        updateItem(itemId) { it.copy(status = StudyStatus.PASS) }
+    }
+
+    private fun updateItem(
+        itemId: Long,
+        transform: (ActStudyItemUiModel) -> ActStudyItemUiModel
+    ) {
+        updateState {
+            copy(
+                items = items.map { item ->
+                    if (item.id == itemId) transform(item) else item
+                }
+            )
+        }
+    }
+}
+
+

--- a/presentation/src/main/res/drawable/bg_danger100_banner.xml
+++ b/presentation/src/main/res/drawable/bg_danger100_banner.xml
@@ -1,0 +1,4 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/danger100"/>
+    <corners android:radius="12dp"/>
+</shape>

--- a/presentation/src/main/res/drawable/bg_neutral100_radius16.xml
+++ b/presentation/src/main/res/drawable/bg_neutral100_radius16.xml
@@ -1,0 +1,4 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/neutral100" />
+    <corners android:radius="16dp" />
+</shape>

--- a/presentation/src/main/res/drawable/bg_primary500_radius8.xml
+++ b/presentation/src/main/res/drawable/bg_primary500_radius8.xml
@@ -1,0 +1,4 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/primary500" />
+    <corners android:radius="8dp" />
+</shape>

--- a/presentation/src/main/res/drawable/bg_success100_banner.xml
+++ b/presentation/src/main/res/drawable/bg_success100_banner.xml
@@ -1,0 +1,4 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/success100"/>
+    <corners android:radius="12dp"/>
+</shape>

--- a/presentation/src/main/res/drawable/bg_warning100_banner.xml
+++ b/presentation/src/main/res/drawable/bg_warning100_banner.xml
@@ -1,0 +1,4 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/warning100"/>
+    <corners android:radius="12dp"/>
+</shape>

--- a/presentation/src/main/res/layout/fragment_user_study.xml
+++ b/presentation/src/main/res/layout/fragment_user_study.xml
@@ -1,12 +1,165 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout xmlns:android="http://schemas.android.com/apk/res/android">
-    <data></data>
-    <FrameLayout
-        android:layout_width="match_parent"
-        android:layout_height="match_parent">
-        <TextView
-            android:layout_width="wrap_content"
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+        <variable
+            name="state"
+            type="com.umc.presentation.ui.act.study.UserStudyState" />
+    </data>
+
+
+    <androidx.core.widget.NestedScrollView
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:fillViewport="true"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
+
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="User Study Fragment" />
-    </FrameLayout>
+            >
+
+
+            <com.google.android.material.card.MaterialCardView
+                android:id="@+id/cv_curriculum"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_margin="16dp"
+                app:cardCornerRadius="16dp"
+                app:cardElevation="0dp"
+                app:cardBackgroundColor="@color/neutral000"
+                app:strokeWidth="0dp"
+                android:stateListAnimator="@null"
+                android:outlineProvider="none"
+                app:rippleColor="@android:color/transparent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent">
+
+                <androidx.constraintlayout.widget.ConstraintLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:padding="16dp">
+
+
+                    <ImageView
+                        android:id="@+id/iv_part_icon"
+                        android:layout_width="24dp"
+                        android:layout_height="24dp"
+                        android:src="@drawable/ic_document"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="parent"
+                        tools:ignore="ContentDescription" />
+
+
+                    <TextView
+                        android:id="@+id/tv_part"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="8dp"
+                        android:textAppearance="@style/Caption2Bold"
+                        android:textColor="@color/primary500"
+                        app:layout_constraintStart_toEndOf="@id/iv_part_icon"
+                        app:layout_constraintTop_toTopOf="@id/iv_part_icon"
+                        app:layout_constraintBottom_toBottomOf="@id/iv_part_icon"
+                        tools:text="WEB PART CURRICULUM" />
+
+
+                    <TextView
+                        android:id="@+id/tv_badge"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:paddingHorizontal="12dp"
+                        android:paddingVertical="6dp"
+                        android:background="@drawable/bg_admin_stats_blue"
+                        android:text="달성률"
+                        android:textAppearance="@style/Caption2Bold"
+                        android:textColor="@color/primary500"
+                        app:layout_constraintTop_toTopOf="parent"
+                        app:layout_constraintEnd_toEndOf="parent" />
+
+
+                    <TextView
+                        android:id="@+id/tv_percent"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="8dp"
+                        android:textAppearance="@style/Title1Bold"
+                        android:textColor="@color/primary500"
+                        app:layout_constraintTop_toBottomOf="@id/tv_part"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        android:text="@{state.percentText}"
+                        />
+
+
+                    <TextView
+                        android:id="@+id/tv_title"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="8dp"
+                        android:textAppearance="@style/Title2Bold"
+                        android:textColor="@color/neutral800"
+                        app:layout_constraintTop_toBottomOf="@id/tv_part"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintEnd_toStartOf="@id/tv_percent"
+                        app:layout_constraintHorizontal_bias="0"
+                        android:text="@{state.title}"
+                        />
+
+
+                    <com.google.android.material.progressindicator.LinearProgressIndicator
+                        android:id="@+id/progress"
+                        android:layout_width="0dp"
+                        android:layout_height="6dp"
+                        android:layout_marginTop="12dp"
+                        app:indicatorColor="@color/primary500"
+                        app:trackColor="@color/neutral200"
+                        app:layout_constraintTop_toBottomOf="@id/tv_title"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        android:progress="@{state.progress}"
+
+                        />
+
+
+                    <TextView
+                        android:id="@+id/tv_sub"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="8dp"
+                        android:textAppearance="@style/Footnote"
+                        android:textColor="@color/neutral500"
+                        app:layout_constraintTop_toBottomOf="@id/progress"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        android:text="@{state.subText}"
+                        />
+
+                </androidx.constraintlayout.widget.ConstraintLayout>
+            </com.google.android.material.card.MaterialCardView>
+
+
+
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/rv_user_study"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:nestedScrollingEnabled="false"
+                android:clipToPadding="false"
+                android:paddingBottom="16dp"
+                app:layout_constraintTop_toBottomOf="@id/cv_curriculum"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                tools:listitem="@layout/item_act_study"
+                tools:itemCount="5" />
+
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </androidx.core.widget.NestedScrollView>
 </layout>

--- a/presentation/src/main/res/layout/item_act_study.xml
+++ b/presentation/src/main/res/layout/item_act_study.xml
@@ -1,0 +1,393 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+        <import type="android.view.View" />
+        <import type="com.umc.presentation.ui.act.study.SubmitState" />
+        <variable
+            name="item"
+            type="com.umc.presentation.ui.act.study.ActStudyItemUiModel" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/timeline_column"
+            android:layout_width="32dp"
+            android:layout_height="0dp"
+            android:layout_marginStart="16dp"
+            app:layout_constraintTop_toTopOf="@id/cv_item"
+            app:layout_constraintBottom_toBottomOf="@id/cv_item"
+            app:layout_constraintStart_toStartOf="parent"
+            app:timelineStatus="@{item.status}"
+            app:timelineWeek="@{item.week}">
+
+
+            <ImageView
+                android:id="@+id/iv_timeline_status"
+                android:layout_width="24dp"
+                android:layout_height="24dp"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                tools:ignore="ContentDescription" />
+
+
+            <TextView
+                android:id="@+id/tv_timeline_number"
+                android:layout_width="24dp"
+                android:layout_height="24dp"
+                android:gravity="center"
+                android:textAppearance="@style/FootnoteBold"
+                android:textColor="@color/neutral000"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                tools:text="3" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+
+        <com.google.android.material.card.MaterialCardView
+            android:id="@+id/cv_item"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:layout_marginEnd="16dp"
+            android:layout_marginVertical="6dp"
+            app:layout_constraintStart_toEndOf="@id/timeline_column"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:cardBackgroundColor="@color/neutral000"
+            app:cardCornerRadius="16dp"
+            app:cardElevation="0dp"
+            app:strokeWidth="0dp"
+            android:stateListAnimator="@null"
+            android:outlineProvider="none"
+            app:rippleColor="@android:color/transparent">
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:padding="16dp">
+
+
+                <LinearLayout
+                    android:id="@+id/layout_tags"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal"
+                    android:gravity="center_vertical"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintEnd_toStartOf="@id/btn_status"
+                    app:layout_constraintTop_toTopOf="parent">
+
+                    <com.umc.presentation.component.UButton
+                        android:layout_width="wrap_content"
+                        android:layout_height="20dp"
+                        android:clickable="false"
+                        android:focusable="false"
+                        app:backgroundColor="@color/neutral000"
+                        app:borderColor="@color/neutral200"
+                        app:borderWidth="1dp"
+                        app:cornerRadius="6dp"
+                        app:contentPaddingLeft="8dp"
+                        app:contentPaddingRight="8dp"
+                        app:text='@{"Week " + item.week}'
+                        app:textAppearance="@style/FootnoteBold"
+                        app:textColor="@color/neutral700"
+                        tools:text="Week 1" />
+
+                    <View
+                        android:layout_width="6dp"
+                        android:layout_height="1dp" />
+
+                    <com.umc.presentation.component.UButton
+                        android:layout_width="wrap_content"
+                        android:layout_height="20dp"
+                        android:clickable="false"
+                        android:focusable="false"
+                        app:backgroundColor="@color/neutral100"
+                        app:borderColor="@color/neutral200"
+                        app:borderWidth="1dp"
+                        app:cornerRadius="6dp"
+                        app:contentPaddingLeft="8dp"
+                        app:contentPaddingRight="8dp"
+                        app:text="@{item.platform}"
+                        app:textAppearance="@style/FootnoteBold"
+                        app:textColor="@color/neutral700"
+                        tools:text="Github" />
+                </LinearLayout>
+
+
+                <com.umc.presentation.component.UButton
+                    android:id="@+id/btn_status"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginEnd="8dp"
+                    app:buttonElevation="0"
+                    app:cornerRadius="4dp"
+                    app:contentPaddingLeft="8dp"
+                    app:contentPaddingRight="8dp"
+                    app:contentPaddingTop="4dp"
+                    app:contentPaddingBottom="4dp"
+                    app:textAppearance="@style/Caption1Bold"
+                    app:studyStatusStyle="@{item.status}"
+                    app:layout_constraintEnd_toStartOf="@id/iv_arrow"
+                    app:layout_constraintTop_toTopOf="@id/top_anchor"
+                    app:layout_constraintBottom_toBottomOf="@id/top_anchor"
+                    tools:text="Pass" />
+
+
+                <ImageView
+                    android:id="@+id/iv_arrow"
+                    android:layout_width="24dp"
+                    android:layout_height="24dp"
+                    android:src='@{item.isExpanded ? @drawable/ic_dropdown_up : @drawable/ic_dropdown_down}'
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toTopOf="@id/top_anchor"
+                    app:layout_constraintBottom_toBottomOf="@id/top_anchor"
+                    tools:src="@drawable/ic_dropdown_down" />
+
+
+                <TextView
+                    android:id="@+id/tv_title"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="10dp"
+                    android:text="@{item.title}"
+                    android:textAppearance="@style/HeadlineBold"
+                    android:textColor="@color/neutral800"
+                    app:layout_constraintTop_toBottomOf="@id/layout_tags"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    tools:text="HTML/CSS 기초" />
+
+
+                <View
+                    android:id="@+id/top_anchor"
+                    android:layout_width="0dp"
+                    android:layout_height="0dp"
+                    app:layout_constraintTop_toTopOf="parent"
+                    app:layout_constraintBottom_toBottomOf="@id/tv_title"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent" />
+
+
+                <LinearLayout
+                    android:id="@+id/layout_expand"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="12dp"
+                    android:orientation="vertical"
+                    android:visibility='@{item.isExpanded ? View.VISIBLE : View.GONE}'
+                    app:layout_constraintTop_toBottomOf="@id/tv_title"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    tools:visibility="visible">
+
+
+                    <LinearLayout
+                        android:id="@+id/layout_input"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="vertical"
+                        app:visibleWhenInput="@{item}"
+                        tools:visibility="visible">
+
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="제출한 링크"
+                            android:textAppearance="@style/SubheadlineBold"
+                            android:textColor="@color/primary500" />
+
+                        <com.umc.presentation.component.UTextField
+                            android:id="@+id/etLink"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="8dp"
+                            app:cornerRadius="12dp"
+                            app:strokeColor="@color/neutral300"
+                            app:strokeWidth="1dp"
+                            app:focusStrokeColor="@color/primary500"
+                            app:placeholderText="링크를 입력하세요."
+                            app:placeholderTextColor="@color/neutral400"
+                            app:textAppearance="@style/Body"
+                            app:textColor="@color/neutral800"
+                            tools:text="http://~" />
+
+                        <com.umc.presentation.component.UButton
+                            android:id="@+id/btnSubmit"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="10dp"
+                            app:buttonElevation="0"
+                            app:cornerRadius="12dp"
+                            app:contentPaddingTop="13dp"
+                            app:contentPaddingBottom="13dp"
+                            app:text="링크 제출하기"
+                            app:textAppearance="@style/CalloutBold" />
+                    </LinearLayout>
+
+
+                    <LinearLayout
+                        android:id="@+id/layout_confirm"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="vertical"
+                        android:layout_marginTop="8dp"
+                        app:visibleWhenConfirming="@{item}"
+                        tools:visibility="visible">
+
+
+                        <LinearLayout
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:orientation="vertical"
+                            android:padding="12dp"
+                            android:background="@drawable/bg_neutral100_radius16">
+
+                            <TextView
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:text="학습을 완료하셨나요?"
+                                android:textAppearance="@style/SubheadlineBold"
+                                android:textColor="@color/neutral800" />
+
+                            <TextView
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_marginTop="4dp"
+                                android:text="버튼을 누르면 학습 인증 요청이 전송됩니다."
+                                android:textAppearance="@style/Footnote"
+                                android:textColor="@color/neutral500" />
+                        </LinearLayout>
+
+
+                        <com.umc.presentation.component.UButton
+                            android:id="@+id/btnConfirm"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="12dp"
+                            app:buttonElevation="0"
+                            app:cornerRadius="12dp"
+                            app:contentPaddingTop="13dp"
+                            app:contentPaddingBottom="13dp"
+                            app:text="학습 완료 인증하기"
+                            app:textAppearance="@style/CalloutBold"
+                            app:confirmButtonStyle="@{true}"
+                            tools:text="학습 완료 인증하기" />
+                    </LinearLayout>
+
+
+
+
+                    <LinearLayout
+                        android:id="@+id/layout_waiting"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="8dp"
+                        android:orientation="horizontal"
+                        android:padding="12dp"
+                        app:visibleWhenWaiting="@{item}"
+                        tools:visibility="gone"
+                        android:background="@drawable/bg_warning100_banner">
+
+                        <ImageView
+                            android:layout_width="20dp"
+                            android:layout_height="20dp"
+                            android:src="@drawable/ic_act_hourglass"
+                            tools:ignore="ContentDescription" />
+
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginStart="8dp"
+                            android:text="학습 확인 대기 중입니다."
+                            android:textAppearance="@style/FootnoteBold"
+                            android:textColor="@color/warning700" />
+                    </LinearLayout>
+
+
+                    <LinearLayout
+                        android:id="@+id/layout_pass"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="8dp"
+                        android:orientation="horizontal"
+                        android:padding="12dp"
+                        app:visibleWhenResultPass="@{item}"
+                        tools:visibility="gone"
+                        android:background="@drawable/bg_success100_banner">
+
+                        <ImageView
+                            android:layout_width="20dp"
+                            android:layout_height="20dp"
+                            android:src="@drawable/ic_check_success"
+                            tools:ignore="ContentDescription" />
+
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginStart="8dp"
+                            android:text="해당 주차 스터디를 통과했습니다."
+                            android:textAppearance="@style/FootnoteBold"
+                            android:textColor="@color/success700" />
+                    </LinearLayout>
+
+                    <LinearLayout
+                        android:id="@+id/layout_fail"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="8dp"
+                        android:orientation="horizontal"
+                        android:padding="12dp"
+                        app:visibleWhenResultFail="@{item}"
+                        tools:visibility="gone"
+                        android:background="@drawable/bg_danger100_banner">
+
+                        <ImageView
+                            android:layout_width="20dp"
+                            android:layout_height="20dp"
+                            android:src="@drawable/ic_check_failed"
+                            tools:ignore="ContentDescription" />
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginStart="8dp"
+                            android:text="해당 주차 스터디를 통과하지 못했습니다."
+                            android:textAppearance="@style/FootnoteBold"
+                            android:textColor="@color/danger700" />
+                    </LinearLayout>
+
+                </LinearLayout>
+
+            </androidx.constraintlayout.widget.ConstraintLayout>
+        </com.google.android.material.card.MaterialCardView>
+
+
+        <View
+            android:id="@+id/tags_bottom_anchor"
+            android:layout_width="0dp"
+            android:layout_height="44dp"
+            app:layout_constraintTop_toTopOf="@id/cv_item"
+            app:layout_constraintStart_toStartOf="@id/timeline_column"
+            app:layout_constraintEnd_toEndOf="@id/timeline_column" />
+
+        <View
+            android:id="@+id/timeline_line"
+            android:layout_width="2dp"
+            android:layout_height="0dp"
+            android:background="@color/neutral200"
+            app:layout_constraintTop_toBottomOf="@id/tags_bottom_anchor"
+            app:layout_constraintBottom_toBottomOf="@id/cv_item"
+            app:layout_constraintStart_toStartOf="@id/timeline_column"
+            app:layout_constraintEnd_toEndOf="@id/timeline_column" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>


### PR DESCRIPTION
## #️⃣ 이슈 번호

> 관련된 이슈 번호를 적어주세요.\
> Close #27 

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 요약해주세요.
활동 탭 내 스터디 진행 화면 UI 구현

- 스터디 전체 진행률 및 완료 현황 표시
- 주차별 스터디 아이템 리스트 구성
- 각 스터디 아이템에 대해
- expand / collapse 가능한 상세 영역 UI 구현
- 스터디 상태(PASS / FAIL / IN_PROGRESS)에 따른 상태 표시 UI 적용

세부적인 디자인은 추후에 같이 올리겠습니다!

## 📸 스크린샷 (선택 사항)
| Collapse | Expand |
| :---: | :---: |
|<img width="378" height="793" alt="image" src="https://github.com/user-attachments/assets/b4957649-2b16-45d6-b044-acae3987853e" />|<img width="367" height="781" alt="image" src="https://github.com/user-attachments/assets/ead0dc2f-2313-4ee9-b3fa-eb3c099eb0a5" />|
| Waiting | confirmation |
| :---: | :---: |
|<img width="382" height="800" alt="image" src="https://github.com/user-attachments/assets/bc60caf8-70e8-4dcf-9941-c44708e92ae0" />|<img width="363" height="782" alt="image" src="https://github.com/user-attachments/assets/7aee0c44-b026-43f9-9c1c-f2d31a8717bf" />|

## 🚩 리뷰 요구사항
> 리뷰어가 중점적으로 봐주었으면 하는 부분이 있다면 작성해주세요.

아이템 expand/collapse 동작 중 flicker 현상이 있습니다...어떤식으로 고치면 좋을까요?


## 🏁 체크리스트
- [ ] 코딩 컨벤션을 준수했나요?
- [ ] 불필요한 로그나 주석을 제거했나요?
- [ ] 머지 대상 브랜치(Base branch)가 올바른가요?
