### PR TITLE
[Feat/#41] 어드민 챌린저 관리 화면 구현

### DIFF
--- a/domain/src/main/java/com/umc/domain/model/act/challenger/AdminChallenger.kt
+++ b/domain/src/main/java/com/umc/domain/model/act/challenger/AdminChallenger.kt
@@ -1,0 +1,13 @@
+package com.umc.domain.model.act.challenger
+
+import com.umc.domain.model.enums.UserPart
+
+data class AdminChallenger(
+    val id: Int,
+    val name: String,
+    val nickname: String,
+    val generation: Int,
+    val part: UserPart,
+    val outCount: Int = 0,
+    val warningCount: Int = 0
+)

--- a/presentation/src/main/java/com/umc/presentation/component/UButtonBindingAdapter.kt
+++ b/presentation/src/main/java/com/umc/presentation/component/UButtonBindingAdapter.kt
@@ -14,4 +14,10 @@ object UButtonBindingAdapter {
     fun setUTextColor(view: UButton, color: Int) {
         view.setTextColor(color)
     }
+
+    @JvmStatic
+    @BindingAdapter("uStrokeColor")
+    fun setUStrokeColor(view: UButton, color: Int) {
+        view.strokeColor = color
+    }
 }

--- a/presentation/src/main/java/com/umc/presentation/ui/act/adapter/AdminChallengerAdapter.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/act/adapter/AdminChallengerAdapter.kt
@@ -1,0 +1,39 @@
+package com.umc.presentation.ui.act.adapter
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.umc.domain.model.act.challenger.AdminChallenger
+import com.umc.presentation.databinding.ItemActAdminChallengerBinding
+
+class AdminChallengerAdapter(
+    private val onItemClick: (Int) -> Unit
+) : ListAdapter<AdminChallenger, AdminChallengerAdapter.ViewHolder>(AdminChallengerDiffCallback()) {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+        val binding = ItemActAdminChallengerBinding.inflate(
+            LayoutInflater.from(parent.context), parent, false
+        )
+        return ViewHolder(binding)
+    }
+
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        holder.bind(getItem(position))
+    }
+
+    inner class ViewHolder(private val binding: ItemActAdminChallengerBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+        fun bind(item: AdminChallenger) {
+            binding.model = item
+            binding.root.setOnClickListener { onItemClick(item.id) }
+            binding.executePendingBindings()
+        }
+    }
+
+    class AdminChallengerDiffCallback : DiffUtil.ItemCallback<AdminChallenger>() {
+        override fun areItemsTheSame(oldItem: AdminChallenger, newItem: AdminChallenger): Boolean = oldItem.id == newItem.id
+        override fun areContentsTheSame(oldItem: AdminChallenger, newItem: AdminChallenger): Boolean = oldItem == newItem
+    }
+}

--- a/presentation/src/main/java/com/umc/presentation/ui/act/challenge/AdminChallengerFragment.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/act/challenge/AdminChallengerFragment.kt
@@ -1,14 +1,89 @@
 package com.umc.presentation.ui.act.challenge
 
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.fragment.app.viewModels
+import androidx.recyclerview.widget.ConcatAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.umc.domain.model.enums.UserPart
+import com.umc.presentation.R
 import com.umc.presentation.base.BaseFragment
 import com.umc.presentation.databinding.FragmentAdminChallengerBinding
+import com.umc.presentation.extension.px
+import com.umc.presentation.ui.act.adapter.ChallengerHeaderAdapter
+import com.umc.presentation.ui.act.adapter.AdminChallengerAdapter
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 
-class AdminChallengerFragment : BaseFragment<FragmentAdminChallengerBinding, Nothing, Nothing, Nothing>(
+@AndroidEntryPoint
+class AdminChallengerFragment : BaseFragment<FragmentAdminChallengerBinding, AdminChallengerUiState, AdminChallengerEvent, AdminChallengerViewModel>(
     FragmentAdminChallengerBinding::inflate
 ) {
-    override val viewModel: Nothing
-        get() = throw IllegalStateException("ViewModel is not used in this Fragment.")
+    override val viewModel: AdminChallengerViewModel by viewModels()
+    private val partOrder = UserPart.entries
+    private val headerAdapters = mutableMapOf<UserPart, ChallengerHeaderAdapter>()
+    private val itemAdapters = mutableMapOf<UserPart, AdminChallengerAdapter>()
 
-    override fun initView() {}
-    override fun initStates() {}
+    override fun initView() {
+        setupRecyclerView()
+
+        // 검색바 텍스트 변경 리스너 연결
+        binding.searchBar.setOnTextChangedListener { text ->
+            viewModel.filterList(text)
+        }
+
+        // 배경 클릭 시 포커스 해제
+        binding.root.setOnClickListener {
+            binding.searchBar.clearFocus()
+            val imm = requireContext().getSystemService(android.content.Context.INPUT_METHOD_SERVICE) as android.view.inputmethod.InputMethodManager
+            imm.hideSoftInputFromWindow(binding.searchBar.windowToken, 0)
+        }
+    }
+
+    private fun setupRecyclerView() {
+        val mainConcatAdapter = ConcatAdapter()
+
+        partOrder.forEach { part ->
+            val headerAdapter = ChallengerHeaderAdapter(part.label)
+            val itemAdapter = AdminChallengerAdapter { id -> /* 상세 이동 로직 */ }
+
+            headerAdapters[part] = headerAdapter
+            itemAdapters[part] = itemAdapter
+
+            mainConcatAdapter.addAdapter(headerAdapter)
+            mainConcatAdapter.addAdapter(itemAdapter)
+        }
+
+        // 하단 여백용 푸터
+        val footerAdapter = object : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
+            override fun onCreateViewHolder(parent: ViewGroup, viewType: Int) =
+                object : RecyclerView.ViewHolder(
+                    LayoutInflater.from(parent.context).inflate(R.layout.item_challenger_list_footer, parent, false)
+                ) {}
+            override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {}
+            override fun getItemCount() = 1
+        }
+        mainConcatAdapter.addAdapter(footerAdapter)
+
+        binding.rvAdminChallengerList.apply {
+            adapter = mainConcatAdapter
+            clipToPadding = false
+            setPadding(0, 0, 0, 64.px)
+        }
+    }
+
+    override fun initStates() {
+        repeatOnStarted(viewLifecycleOwner) {
+            launch {
+                viewModel.uiState.collect { state ->
+                    val grouped = state.filteredChallengers.groupBy { it.part }
+                    partOrder.forEach { part ->
+                        val list = grouped[part] ?: emptyList()
+                        headerAdapters[part]?.updateCount(list.size)
+                        itemAdapters[part]?.submitList(list)
+                    }
+                }
+            }
+        }
+    }
 }

--- a/presentation/src/main/java/com/umc/presentation/ui/act/challenge/AdminChallengerViewModel.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/act/challenge/AdminChallengerViewModel.kt
@@ -1,0 +1,45 @@
+package com.umc.presentation.ui.act.challenge
+
+import com.umc.domain.model.act.challenger.AdminChallenger
+import com.umc.domain.model.enums.UserPart
+import com.umc.presentation.base.BaseViewModel
+import com.umc.presentation.base.UiEvent
+import com.umc.presentation.base.UiState
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class AdminChallengerViewModel @Inject constructor() :
+    BaseViewModel<AdminChallengerUiState, AdminChallengerEvent>(AdminChallengerUiState()) {
+
+    init { loadInitialData() }
+
+    private fun loadInitialData() {
+        val dummyList = listOf(
+            AdminChallenger(1, "홍길동", "닉네임", 12, UserPart.PM, outCount = 1, warningCount = 1),
+            AdminChallenger(2, "홍길동", "닉네임", 12, UserPart.DESIGN, outCount = 1, warningCount = 1),
+            AdminChallenger(3, "홍길동", "닉네임", 12, UserPart.DESIGN, outCount = 1, warningCount = 1),
+            AdminChallenger(4, "홍길동", "닉네임", 12, UserPart.WEB),
+            AdminChallenger(5, "홍길동", "닉네임", 12, UserPart.WEB),
+            AdminChallenger(6, "홍길동", "닉네임", 12, UserPart.WEB),
+            AdminChallenger(7, "홍길동", "닉네임", 12, UserPart.IOS)
+        )
+        updateState { copy(allChallengers = dummyList, filteredChallengers = dummyList) }
+    }
+
+    fun filterList(query: String) {
+        val filtered = uiState.value.allChallengers.filter {
+            it.name.contains(query) || it.nickname.contains(query)
+        }
+        updateState { copy(filteredChallengers = filtered) }
+    }
+}
+
+data class AdminChallengerUiState(
+    val allChallengers: List<AdminChallenger> = emptyList(),
+    val filteredChallengers: List<AdminChallenger> = emptyList()
+) : UiState
+
+sealed class AdminChallengerEvent : UiEvent {
+    data class NavigateToDetail(val id: Int) : AdminChallengerEvent()
+}

--- a/presentation/src/main/java/com/umc/presentation/ui/act/challenge/UserChallengerFragment.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/act/challenge/UserChallengerFragment.kt
@@ -64,7 +64,7 @@ class UserChallengerFragment : BaseFragment<FragmentUserChallengerBinding, UserC
         binding.rvChallengerList.apply {
             adapter = mainConcatAdapter
             clipToPadding = false
-            setPadding(1, 1, 1, 64.px)
+            setPadding(0, 0, 0, 64.px)
         }
     }
 

--- a/presentation/src/main/res/layout/fragment_admin_challenger.xml
+++ b/presentation/src/main/res/layout/fragment_admin_challenger.xml
@@ -27,7 +27,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="16dp"
-                android:text="챌린저 리스트"
+                android:text="@string/challenger_list_title"
                 android:textAppearance="@style/Title3Bold"
                 android:textColor="@color/neutral900"
                 app:layout_constraintStart_toStartOf="parent"
@@ -40,7 +40,7 @@
                 android:layout_marginHorizontal="16dp"
                 android:layout_marginTop="16dp"
                 app:cornerRadius="8dp"
-                app:placeholderText="이름으로 멤버 검색"
+                app:placeholderText="@string/challenger_search_placeholder"
                 app:onTextChanged="@{(text) -> viewModel.filterList(text)}"
                 app:layout_constraintTop_toBottomOf="@id/tv_list_title" />
         </androidx.constraintlayout.widget.ConstraintLayout>

--- a/presentation/src/main/res/layout/fragment_admin_challenger.xml
+++ b/presentation/src/main/res/layout/fragment_admin_challenger.xml
@@ -1,12 +1,60 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout xmlns:android="http://schemas.android.com/apk/res/android">
-    <data></data>
-    <FrameLayout
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <data>
+        <variable name="viewModel" type="com.umc.presentation.ui.act.challenge.AdminChallengerViewModel" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
-        <TextView
-            android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:background="@color/neutral100">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/layout_fixed_header"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="Admin Challenge Fragment" />
-    </FrameLayout>
+            android:layout_marginHorizontal="16dp"
+            android:layout_marginTop="16dp"
+            android:background="@drawable/bg_card_top"
+            android:paddingTop="16dp"
+            android:paddingBottom="12dp"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <TextView
+                android:id="@+id/tv_list_title"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:text="챌린저 리스트"
+                android:textAppearance="@style/Title3Bold"
+                android:textColor="@color/neutral900"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <com.umc.presentation.component.USearchBar
+                android:id="@+id/search_bar"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="16dp"
+                android:layout_marginTop="16dp"
+                app:cornerRadius="8dp"
+                app:placeholderText="이름으로 멤버 검색"
+                app:onTextChanged="@{(text) -> viewModel.filterList(text)}"
+                app:layout_constraintTop_toBottomOf="@id/tv_list_title" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/rv_admin_challenger_list"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_marginHorizontal="16dp"
+            android:background="@android:color/transparent"
+            android:clipToPadding="false"
+            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+            app:layout_constraintTop_toBottomOf="@id/layout_fixed_header"
+            app:layout_constraintBottom_toBottomOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/presentation/src/main/res/layout/item_act_admin_challenger.xml
+++ b/presentation/src/main/res/layout/item_act_admin_challenger.xml
@@ -19,7 +19,7 @@
         <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:paddingVertical="14dp"
+            android:paddingVertical="16dp"
             app:layout_constraintTop_toTopOf="parent">
 
             <com.google.android.material.imageview.ShapeableImageView
@@ -40,7 +40,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="8dp"
-                android:text='@{model.name + "(" + model.nickname + ")"}'
+                android:text="@{@string/challenger_name_nickname_format(model.name, model.nickname)}"
                 android:textAppearance="@style/BodyBold"
                 android:textColor="@color/neutral800"
                 app:layout_constraintBottom_toBottomOf="parent"
@@ -100,7 +100,7 @@
                     app:textAppearance="@style/Caption1Bold"
                     app:uBackgroundColor="@{@color/danger100}"
                     app:uTextColor="@{@color/danger700}"
-                    android:text='@{"아웃 " + model.outCount}'
+                    android:text="@{@string/admin_challenger_out_count(model.outCount)}"
                     tools:text="아웃 1" />
 
                 <com.umc.presentation.component.UButton
@@ -120,7 +120,7 @@
                     app:textAppearance="@style/Caption1Bold"
                     app:uBackgroundColor="@{@color/warning100}"
                     app:uTextColor="@{@color/warning700}"
-                    android:text='@{"경고 " + model.warningCount}'
+                    android:text="@{@string/admin_challenger_warning_count(model.warningCount)}"
                     tools:text="경고 1" />
             </LinearLayout>
 

--- a/presentation/src/main/res/layout/item_act_admin_challenger.xml
+++ b/presentation/src/main/res/layout/item_act_admin_challenger.xml
@@ -41,7 +41,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginStart="8dp"
                 android:text='@{model.name + "(" + model.nickname + ")"}'
-                android:textAppearance="@style/SubheadlineBold"
+                android:textAppearance="@style/BodyBold"
                 android:textColor="@color/neutral800"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintStart_toEndOf="@+id/iv_challenger_profile"
@@ -54,7 +54,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginStart="8dp"
                 android:text='@{model.generation + "기"}'
-                android:textAppearance="@style/Footnote"
+                android:textAppearance="@style/Subheadline"
                 android:textColor="@color/neutral400"
                 app:layout_constraintBottom_toBottomOf="@+id/tv_challenger_name"
                 app:layout_constraintStart_toEndOf="@+id/tv_challenger_name"

--- a/presentation/src/main/res/layout/item_act_admin_challenger.xml
+++ b/presentation/src/main/res/layout/item_act_admin_challenger.xml
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+        <import type="android.view.View" />
+        <variable
+            name="model"
+            type="com.umc.domain.model.act.challenger.AdminChallenger" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@drawable/bg_card_middle"
+        android:paddingHorizontal="16dp">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingVertical="14dp"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <com.google.android.material.imageview.ShapeableImageView
+                android:id="@+id/iv_challenger_profile"
+                android:layout_width="32dp"
+                android:layout_height="32dp"
+                android:scaleType="centerInside"
+                android:src="@drawable/ic_person_inset"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:shapeAppearanceOverlay="@style/CircleImageAppearance"
+                app:strokeColor="@color/neutral100"
+                app:strokeWidth="1dp" />
+
+            <TextView
+                android:id="@+id/tv_challenger_name"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:text='@{model.name + "(" + model.nickname + ")"}'
+                android:textAppearance="@style/SubheadlineBold"
+                android:textColor="@color/neutral800"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toEndOf="@+id/iv_challenger_profile"
+                app:layout_constraintTop_toTopOf="parent"
+                tools:text="홍길동(닉네임)" />
+
+            <TextView
+                android:id="@+id/tv_challenger_generation"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:text='@{model.generation + "기"}'
+                android:textAppearance="@style/Footnote"
+                android:textColor="@color/neutral400"
+                app:layout_constraintBottom_toBottomOf="@+id/tv_challenger_name"
+                app:layout_constraintStart_toEndOf="@+id/tv_challenger_name"
+                app:layout_constraintTop_toTopOf="@+id/tv_challenger_name"
+                tools:text="12기" />
+
+            <ImageView
+                android:id="@+id/iv_challenger_detail_arrow"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:paddingHorizontal="8dp"
+                android:paddingVertical="6dp"
+                android:src="@drawable/ic_arrow_next"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:tint="@color/neutral300" />
+
+            <LinearLayout
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="8dp"
+                android:orientation="horizontal"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toStartOf="@id/iv_challenger_detail_arrow"
+                app:layout_constraintTop_toTopOf="parent">
+
+                <com.umc.presentation.component.UButton
+                    android:id="@+id/ub_out_count"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginEnd="4dp"
+                    android:clickable="false"
+                    android:visibility="@{model.outCount > 0 ? View.VISIBLE : View.GONE}"
+                    app:borderWidth="1dp"
+                    app:buttonElevation="0"
+                    app:contentPaddingBottom="4dp"
+                    app:contentPaddingLeft="8dp"
+                    app:contentPaddingRight="8dp"
+                    app:contentPaddingTop="4dp"
+                    app:cornerRadius="4dp"
+                    app:uStrokeColor="@{@color/danger300}"
+                    app:textAppearance="@style/Caption1Bold"
+                    app:uBackgroundColor="@{@color/danger100}"
+                    app:uTextColor="@{@color/danger700}"
+                    android:text='@{"아웃 " + model.outCount}'
+                    tools:text="아웃 1" />
+
+                <com.umc.presentation.component.UButton
+                    android:id="@+id/ub_warning_count"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:clickable="false"
+                    android:visibility="@{model.warningCount > 0 ? View.VISIBLE : View.GONE}"
+                    app:borderWidth="1dp"
+                    app:buttonElevation="0"
+                    app:contentPaddingBottom="4dp"
+                    app:contentPaddingLeft="8dp"
+                    app:contentPaddingRight="8dp"
+                    app:contentPaddingTop="4dp"
+                    app:cornerRadius="4dp"
+                    app:uStrokeColor="@{@color/warning300}"
+                    app:textAppearance="@style/Caption1Bold"
+                    app:uBackgroundColor="@{@color/warning100}"
+                    app:uTextColor="@{@color/warning700}"
+                    android:text='@{"경고 " + model.warningCount}'
+                    tools:text="경고 1" />
+            </LinearLayout>
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/presentation/src/main/res/layout/item_act_user_challenger.xml
+++ b/presentation/src/main/res/layout/item_act_user_challenger.xml
@@ -40,7 +40,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginStart="8dp"
                 android:text='@{model.name + "(" + model.nickname + ")"}'
-                android:textAppearance="@style/SubheadlineBold"
+                android:textAppearance="@style/BodyBold"
                 android:textColor="@color/neutral800"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintStart_toEndOf="@+id/iv_challenger_profile"
@@ -53,7 +53,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginStart="8dp"
                 android:text='@{model.generation + "기"}'
-                android:textAppearance="@style/Footnote"
+                android:textAppearance="@style/Subheadline"
                 android:textColor="@color/neutral400"
                 app:layout_constraintBottom_toBottomOf="@+id/tv_challenger_name"
                 app:layout_constraintStart_toEndOf="@+id/tv_challenger_name"

--- a/presentation/src/main/res/layout/item_act_user_challenger.xml
+++ b/presentation/src/main/res/layout/item_act_user_challenger.xml
@@ -18,7 +18,7 @@
         <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:paddingVertical="14dp"
+            android:paddingVertical="16dp"
             app:layout_constraintTop_toTopOf="parent">
 
             <com.google.android.material.imageview.ShapeableImageView
@@ -39,7 +39,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="8dp"
-                android:text='@{model.name + "(" + model.nickname + ")"}'
+                android:text="@{@string/challenger_name_nickname_format(model.name, model.nickname)}"
                 android:textAppearance="@style/BodyBold"
                 android:textColor="@color/neutral800"
                 app:layout_constraintBottom_toBottomOf="parent"

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -169,8 +169,13 @@
     <string name="admin_pending_user_request_time_format">%1$s 요청</string>
     <string name="attendance_empty_admin_sessions">아직 출석을 진행할 세션이 없어요</string>
 
-    <!-- TODO: Remove or change this placeholder text -->
-    <string name="hello_blank_fragment">Hello blank fragment</string>
     <string name="challenger_list_title">챌린저 리스트</string>
     <string name="challenger_search_placeholder">이름으로 멤버 검색</string>
+    <string name="admin_challenger_out_count">아웃 %d</string>
+    <string name="admin_challenger_warning_count">경고 %d</string>
+    <string name="challenger_name_nickname_format">%1$s(%2$s)</string>
+
+    <!-- TODO: Remove or change this placeholder text -->
+    <string name="hello_blank_fragment">Hello blank fragment</string>
+
 </resources>


### PR DESCRIPTION
## #️⃣ 이슈 번호

> 관련된 이슈 번호를 적어주세요.\
> Close #41 

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 요약해주세요.

활동 탭에서 어드민 권한의 챌린저 화면을 구현합니다. 이 화면에서는 아웃과 경고 횟수를 포함하고 있습니다.

## 📸 스크린샷 (선택 사항)
| 라이트 모드 | 다크 모드 |
| :---: | :---: |
| <img width="350" alt="image" src="https://github.com/user-attachments/assets/38a0d69a-cf90-488a-87b1-60f14a826397" /> | <img width="350" alt="image" src="https://github.com/user-attachments/assets/98438dcf-36be-4763-9161-3e3561daf1a9" />|

UI가 태그 제외하고는 같아서 영상 없이 스크린샷만 추가하였습니다.

## 🚩 리뷰 요구사항
> 리뷰어가 중점적으로 봐주었으면 하는 부분이 있다면 작성해주세요.

## 🏁 체크리스트
- [ ] 코딩 컨벤션을 준수했나요?
- [ ] 불필요한 로그나 주석을 제거했나요?
- [ ] 머지 대상 브랜치(Base branch)가 올바른가요?
