### PR TITLE
[Feat/#57] 챌린지 정보 조회 API 연동

### DIFF
--- a/app/src/main/java/com/umc/product/di/ApiModule.kt
+++ b/app/src/main/java/com/umc/product/di/ApiModule.kt
@@ -1,6 +1,7 @@
 package com.umc.product.di
 
 import com.umc.data.api.AuthApi
+import com.umc.data.api.ChallengerApi
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -16,5 +17,11 @@ object ApiModule {
     @Provides
     fun provideAuthApi(@NormalRetrofit retrofit: Retrofit): AuthApi {
         return retrofit.create(AuthApi::class.java)
+    }
+
+    @Singleton
+    @Provides
+    fun provideChallengerApi(@AuthRetrofit retrofit: Retrofit): ChallengerApi {
+        return retrofit.create(ChallengerApi::class.java)
     }
 }

--- a/app/src/main/java/com/umc/product/di/DataSourceModule.kt
+++ b/app/src/main/java/com/umc/product/di/DataSourceModule.kt
@@ -1,7 +1,9 @@
 package com.umc.product.di
 
 import com.umc.data.dataSource.AuthRemoteDataSource
+import com.umc.data.dataSource.ChallengerRemoteDataSource
 import com.umc.data.dataSource.remote.AuthRemoteDataSourceImpl
+import com.umc.data.dataSource.remote.ChallengerRemoteDataSourceImpl
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -14,4 +16,8 @@ abstract class DataSourceModule {
     @Singleton
     @Binds
     abstract fun providesAuthDataSource(dataSourceImpl: AuthRemoteDataSourceImpl): AuthRemoteDataSource
+
+    @Singleton
+    @Binds
+    abstract fun bindsChallengerRemoteDataSource(dataSourceImpl: ChallengerRemoteDataSourceImpl): ChallengerRemoteDataSource
 }

--- a/app/src/main/java/com/umc/product/di/RepositoryModule.kt
+++ b/app/src/main/java/com/umc/product/di/RepositoryModule.kt
@@ -1,7 +1,9 @@
 package com.umc.product.di
 
 import com.umc.data.repository.AuthRepositoryImpl
+import com.umc.data.repository.ChallengerRepositoryImpl
 import com.umc.domain.repository.AuthRepository
+import com.umc.domain.repository.ChallengerRepository
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -14,4 +16,8 @@ abstract class RepositoryModule {
     @Singleton
     @Binds
     abstract fun providesAuthRepository(repositoryImpl: AuthRepositoryImpl): AuthRepository
+
+    @Singleton
+    @Binds
+    abstract fun bindsChallengerRepository(repositoryImpl: ChallengerRepositoryImpl): ChallengerRepository
 }

--- a/app/src/main/java/com/umc/product/di/UseCaseModule.kt
+++ b/app/src/main/java/com/umc/product/di/UseCaseModule.kt
@@ -1,6 +1,8 @@
 package com.umc.product.di
 
 import com.umc.domain.repository.AuthRepository
+import com.umc.domain.repository.ChallengerRepository
+import com.umc.domain.usecase.GetChallengerDetailUseCase
 import com.umc.domain.usecase.PostLoginUseCase
 import dagger.Module
 import dagger.Provides
@@ -15,5 +17,11 @@ object UseCaseModule {
     @Provides
     fun providesPostLoginUseCase(repository: AuthRepository): PostLoginUseCase {
         return PostLoginUseCase(repository)
+    }
+
+    @Singleton
+    @Provides
+    fun providesGetChallengerDetailUseCase(repository: ChallengerRepository): GetChallengerDetailUseCase {
+        return GetChallengerDetailUseCase(repository)
     }
 }

--- a/data/src/main/java/com/umc/data/api/ChallengerApi.kt
+++ b/data/src/main/java/com/umc/data/api/ChallengerApi.kt
@@ -1,0 +1,14 @@
+package com.umc.data.api
+
+import com.umc.data.response.ChallengerResponse
+import com.umc.domain.model.base.ApiResponse
+import com.umc.domain.model.base.ApiState
+import retrofit2.http.GET
+import retrofit2.http.Path
+
+interface ChallengerApi {
+    @GET(Endpoints.Challenger.DETAIL)
+    suspend fun getChallengerDetail(
+        @Path("challengerId") challengerId: Long
+    ): ApiResponse<ChallengerResponse>
+}

--- a/data/src/main/java/com/umc/data/api/Endpoints.kt
+++ b/data/src/main/java/com/umc/data/api/Endpoints.kt
@@ -10,5 +10,10 @@ object Endpoints {
         const val EMAIL_VERIFICATION = "$AUTH/email-verification"
         const val EMAIL_VERIFICATION_COMPLETE = "$EMAIL_VERIFICATION/complete"
     }
+
+    object Challenger {
+        const val CHALLENGER = "api/v1/challenger"
+        const val DETAIL = "$CHALLENGER/{challengerId}"
+    }
     // TODO 경로명 입력
 }

--- a/data/src/main/java/com/umc/data/dataSource/ChallengerRemoteDataSource.kt
+++ b/data/src/main/java/com/umc/data/dataSource/ChallengerRemoteDataSource.kt
@@ -1,0 +1,8 @@
+package com.umc.data.dataSource
+
+import com.umc.data.response.ChallengerResponse
+import com.umc.domain.model.base.ApiState
+
+interface ChallengerRemoteDataSource {
+    suspend fun getChallengerDetail(id: Long): ApiState<ChallengerResponse>
+}

--- a/data/src/main/java/com/umc/data/dataSource/remote/ChallengerRemoteDataSourceImpl.kt
+++ b/data/src/main/java/com/umc/data/dataSource/remote/ChallengerRemoteDataSourceImpl.kt
@@ -1,11 +1,12 @@
 package com.umc.data.dataSource.remote
 
+import com.google.gson.Gson
 import com.umc.data.api.ChallengerApi
 import com.umc.data.dataSource.ChallengerRemoteDataSource
 import com.umc.data.response.ChallengerResponse
+import com.umc.domain.model.base.ApiResponse
 import com.umc.domain.model.base.ApiState
 import com.umc.domain.model.base.FailState
-import com.umc.domain.model.base.mapSuccessData
 import javax.inject.Inject
 
 class ChallengerRemoteDataSourceImpl @Inject constructor(
@@ -14,13 +15,23 @@ class ChallengerRemoteDataSourceImpl @Inject constructor(
     override suspend fun getChallengerDetail(id: Long): ApiState<ChallengerResponse> {
         return try {
             val response = challengerApi.getChallengerDetail(id)
+
             if (response.success) {
                 ApiState.Success(response.result ?: throw Exception("Data is null"))
             } else {
                 ApiState.Fail(FailState(false, response.code, response.message))
             }
+        } catch (e: retrofit2.HttpException) {
+            val errorBody = e.response()?.errorBody()?.string()
+            val errorResponse = Gson().fromJson(errorBody, ApiResponse::class.java)
+
+            ApiState.Fail(FailState(
+                isSuccess = false,
+                code = errorResponse?.code ?: "HTTP_${e.code()}",
+                message = errorResponse?.message ?: "서버 에러가 발생했습니다."
+            ))
         } catch (e: Exception) {
-            ApiState.Fail(FailState(false, "ERROR", e.message ?: "Unknown Error"))
+            ApiState.Fail(FailState(false, "UNKNOWN", e.message ?: "알 수 없는 오류"))
         }
     }
 }

--- a/data/src/main/java/com/umc/data/dataSource/remote/ChallengerRemoteDataSourceImpl.kt
+++ b/data/src/main/java/com/umc/data/dataSource/remote/ChallengerRemoteDataSourceImpl.kt
@@ -1,0 +1,26 @@
+package com.umc.data.dataSource.remote
+
+import com.umc.data.api.ChallengerApi
+import com.umc.data.dataSource.ChallengerRemoteDataSource
+import com.umc.data.response.ChallengerResponse
+import com.umc.domain.model.base.ApiState
+import com.umc.domain.model.base.FailState
+import com.umc.domain.model.base.mapSuccessData
+import javax.inject.Inject
+
+class ChallengerRemoteDataSourceImpl @Inject constructor(
+    private val challengerApi: ChallengerApi
+) : ChallengerRemoteDataSource {
+    override suspend fun getChallengerDetail(id: Long): ApiState<ChallengerResponse> {
+        return try {
+            val response = challengerApi.getChallengerDetail(id)
+            if (response.success) {
+                ApiState.Success(response.result ?: throw Exception("Data is null"))
+            } else {
+                ApiState.Fail(FailState(false, response.code, response.message))
+            }
+        } catch (e: Exception) {
+            ApiState.Fail(FailState(false, "ERROR", e.message ?: "Unknown Error"))
+        }
+    }
+}

--- a/data/src/main/java/com/umc/data/repository/ChallengerRepositoryImpl.kt
+++ b/data/src/main/java/com/umc/data/repository/ChallengerRepositoryImpl.kt
@@ -1,8 +1,10 @@
 package com.umc.data.repository
 
 import com.umc.data.dataSource.ChallengerRemoteDataSource
+import com.umc.data.response.ChallengerResponse.Companion.toManageModel
 import com.umc.data.response.ChallengerResponse.Companion.toModel
 import com.umc.domain.model.act.challenger.ChallengerInfoDialogModel
+import com.umc.domain.model.act.challenger.ChallengerManageDialogModel
 import com.umc.domain.model.base.ApiState
 import com.umc.domain.model.base.map
 import com.umc.domain.repository.ChallengerRepository
@@ -14,6 +16,12 @@ class ChallengerRepositoryImpl @Inject constructor(
     override suspend fun getChallengerInfo(id: Long): ApiState<ChallengerInfoDialogModel> {
         return challengerRemoteDataSource.getChallengerDetail(id).map {
             it.toModel()
+        }
+    }
+
+    override suspend fun getAdminChallengerInfo(id: Long): ApiState<ChallengerManageDialogModel> {
+        return challengerRemoteDataSource.getChallengerDetail(id).map {
+            it.toManageModel()
         }
     }
 }

--- a/data/src/main/java/com/umc/data/repository/ChallengerRepositoryImpl.kt
+++ b/data/src/main/java/com/umc/data/repository/ChallengerRepositoryImpl.kt
@@ -1,0 +1,19 @@
+package com.umc.data.repository
+
+import com.umc.data.dataSource.ChallengerRemoteDataSource
+import com.umc.data.response.ChallengerResponse.Companion.toModel
+import com.umc.domain.model.act.challenger.ChallengerInfoDialogModel
+import com.umc.domain.model.base.ApiState
+import com.umc.domain.model.base.map
+import com.umc.domain.repository.ChallengerRepository
+import javax.inject.Inject
+
+class ChallengerRepositoryImpl @Inject constructor(
+    private val challengerRemoteDataSource: ChallengerRemoteDataSource
+) : ChallengerRepository {
+    override suspend fun getChallengerInfo(id: Long): ApiState<ChallengerInfoDialogModel> {
+        return challengerRemoteDataSource.getChallengerDetail(id).map {
+            it.toModel()
+        }
+    }
+}

--- a/data/src/main/java/com/umc/data/response/ChallengerResponse.kt
+++ b/data/src/main/java/com/umc/data/response/ChallengerResponse.kt
@@ -2,6 +2,7 @@ package com.umc.data.response
 
 import com.google.gson.annotations.SerializedName
 import com.umc.domain.model.act.challenger.ChallengerInfoDialogModel
+import com.umc.domain.model.act.challenger.ChallengerManageDialogModel
 
 data class ChallengerResponse(
     @SerializedName("challengerId") val challengerId: Long? = null,
@@ -26,6 +27,17 @@ data class ChallengerResponse(
                 university = schoolName ?: defaultModel.university,
                 part = part ?: defaultModel.part,
                 generation = gisu ?: defaultModel.generation,
+                profileImageUrl = profileImageLink ?: defaultModel.profileImageUrl
+            )
+        }
+
+        fun ChallengerResponse.toManageModel(): ChallengerManageDialogModel {
+            val defaultModel = ChallengerManageDialogModel()
+
+            return ChallengerManageDialogModel(
+                name = name ?: defaultModel.name,
+                university = schoolName ?: defaultModel.university,
+                part = part ?: defaultModel.part,
                 profileImageUrl = profileImageLink ?: defaultModel.profileImageUrl
             )
         }

--- a/data/src/main/java/com/umc/data/response/ChallengerResponse.kt
+++ b/data/src/main/java/com/umc/data/response/ChallengerResponse.kt
@@ -18,13 +18,17 @@ data class ChallengerResponse(
     @SerializedName("status") val status: String? = null
 ) {
     companion object {
-        fun ChallengerResponse.toModel() = ChallengerInfoDialogModel(
-            name = name ?: "",
-            university = schoolName ?: "",
-            part = part ?: "",
-            generation = gisu ?: 0,
-            profileImageUrl = profileImageLink ?: ""
-        )
+        fun ChallengerResponse.toModel(): ChallengerInfoDialogModel {
+            val defaultModel = ChallengerInfoDialogModel()
+
+            return ChallengerInfoDialogModel(
+                name = name ?: defaultModel.name,
+                university = schoolName ?: defaultModel.university,
+                part = part ?: defaultModel.part,
+                generation = gisu ?: defaultModel.generation,
+                profileImageUrl = profileImageLink ?: defaultModel.profileImageUrl
+            )
+        }
     }
 }
 

--- a/data/src/main/java/com/umc/data/response/ChallengerResponse.kt
+++ b/data/src/main/java/com/umc/data/response/ChallengerResponse.kt
@@ -1,0 +1,36 @@
+package com.umc.data.response
+
+import com.google.gson.annotations.SerializedName
+import com.umc.domain.model.act.challenger.ChallengerInfoDialogModel
+
+data class ChallengerResponse(
+    @SerializedName("challengerId") val challengerId: Long? = null,
+    @SerializedName("memberId") val memberId: Long? = null,
+    @SerializedName("gisu") val gisu: Int? = null,
+    @SerializedName("part") val part: String? = null,
+    @SerializedName("challengerPoints") val challengerPoints: List<PointResponse>? = null,
+    @SerializedName("name") val name: String? = null,
+    @SerializedName("nickname") val nickname: String? = null,
+    @SerializedName("email") val email: String? = null,
+    @SerializedName("schoolId") val schoolId: Int? = null,
+    @SerializedName("schoolName") val schoolName: String? = null,
+    @SerializedName("profileImageLink") val profileImageLink: String? = null,
+    @SerializedName("status") val status: String? = null
+) {
+    companion object {
+        fun ChallengerResponse.toModel() = ChallengerInfoDialogModel(
+            name = name ?: "",
+            university = schoolName ?: "",
+            part = part ?: "",
+            generation = gisu ?: 0,
+            profileImageUrl = profileImageLink ?: ""
+        )
+    }
+}
+
+data class PointResponse(
+    @SerializedName("id") val id: Int? = null,
+    @SerializedName("pointType") val pointType: String? = null,
+    @SerializedName("point") val point: Double? = null,
+    @SerializedName("description") val description: String? = null
+)

--- a/domain/src/main/java/com/umc/domain/model/act/challenger/ChallengerInfoDialogModel.kt
+++ b/domain/src/main/java/com/umc/domain/model/act/challenger/ChallengerInfoDialogModel.kt
@@ -5,19 +5,20 @@ import com.umc.domain.model.enums.CheckHistoryStatus
 /**
  * 다이얼로그의 출석/활동 기록 리스트 아이템 모델
  */
-data class SimpleHistoryItem(
-    val title: String,
-    val status: CheckHistoryStatus
+data class ChallengerInfoHistory(
+    val title: String = "",
+    val status: CheckHistoryStatus = CheckHistoryStatus.ABSENT
 )
 
 /**
  * 챌린저 상세 정보 다이얼로그 전체 데이터 모델
  */
 data class ChallengerInfoDialogModel(
-    val name: String,
-    val university: String,
-    val part: String,
-    val generation: String = "12기",
+    val name: String = "알수없음",
+    val university: String = "알수없음",
+    val part: String = "알수없음",
+    val generation: Int = 0,
+    val profileImageUrl: String = "",
     val warningCount: Double = 0.0,
-    val history: List<SimpleHistoryItem> = emptyList()
+    val history: List<ChallengerInfoHistory> = emptyList()
 )

--- a/domain/src/main/java/com/umc/domain/model/act/challenger/ChallengerManageDialogModel.kt
+++ b/domain/src/main/java/com/umc/domain/model/act/challenger/ChallengerManageDialogModel.kt
@@ -1,9 +1,10 @@
 package com.umc.domain.model.act.challenger
 
-data class UChallengerManageDialogModel(
-    val name: String,
-    val university: String,
-    val part: String,
+data class ChallengerManageDialogModel(
+    val name: String = "알수없음",
+    val university: String = "알수없음",
+    val part: String = "알수없음",
+    val profileImageUrl: String = "",
     val hasNewAbsence: Boolean = false,
     val absenceCount: Int = 0,
     val warningCount: Int = 0,

--- a/domain/src/main/java/com/umc/domain/model/base/ApiResponse.kt
+++ b/domain/src/main/java/com/umc/domain/model/base/ApiResponse.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class ApiResponse<T>(
-    val isSuccess: Boolean = false,
+    val success: Boolean = false,
     val code: String,
     val message: String,
     val result: T? = null,

--- a/domain/src/main/java/com/umc/domain/repository/ChallengerRepository.kt
+++ b/domain/src/main/java/com/umc/domain/repository/ChallengerRepository.kt
@@ -1,8 +1,13 @@
 package com.umc.domain.repository
 
 import com.umc.domain.model.act.challenger.ChallengerInfoDialogModel
+import com.umc.domain.model.act.challenger.ChallengerManageDialogModel
 import com.umc.domain.model.base.ApiState
 
 interface ChallengerRepository {
+    // 유저용 상세 정보
     suspend fun getChallengerInfo(id: Long): ApiState<ChallengerInfoDialogModel>
+
+    // 관리자용 상세 정보
+    suspend fun getAdminChallengerInfo(id: Long): ApiState<ChallengerManageDialogModel>
 }

--- a/domain/src/main/java/com/umc/domain/repository/ChallengerRepository.kt
+++ b/domain/src/main/java/com/umc/domain/repository/ChallengerRepository.kt
@@ -1,0 +1,8 @@
+package com.umc.domain.repository
+
+import com.umc.domain.model.act.challenger.ChallengerInfoDialogModel
+import com.umc.domain.model.base.ApiState
+
+interface ChallengerRepository {
+    suspend fun getChallengerInfo(id: Long): ApiState<ChallengerInfoDialogModel>
+}

--- a/domain/src/main/java/com/umc/domain/usecase/GetAdminChallengerDetailUseCase.kt
+++ b/domain/src/main/java/com/umc/domain/usecase/GetAdminChallengerDetailUseCase.kt
@@ -1,0 +1,14 @@
+package com.umc.domain.usecase
+
+import com.umc.domain.model.act.challenger.ChallengerManageDialogModel
+import com.umc.domain.model.base.ApiState
+import com.umc.domain.repository.ChallengerRepository
+import javax.inject.Inject
+
+class GetAdminChallengerDetailUseCase @Inject constructor(
+    private val challengerRepository: ChallengerRepository
+) {
+    suspend operator fun invoke(id: Long): ApiState<ChallengerManageDialogModel> {
+        return challengerRepository.getAdminChallengerInfo(id)
+    }
+}

--- a/domain/src/main/java/com/umc/domain/usecase/GetChallengerDetailUseCase.kt
+++ b/domain/src/main/java/com/umc/domain/usecase/GetChallengerDetailUseCase.kt
@@ -1,0 +1,14 @@
+package com.umc.domain.usecase
+
+import com.umc.domain.model.act.challenger.ChallengerInfoDialogModel
+import com.umc.domain.model.base.ApiState
+import com.umc.domain.repository.ChallengerRepository
+import javax.inject.Inject
+
+class GetChallengerDetailUseCase @Inject constructor(
+    private val challengerRepository: ChallengerRepository
+) {
+    suspend operator fun invoke(id: Long): ApiState<ChallengerInfoDialogModel> {
+        return challengerRepository.getChallengerInfo(id)
+    }
+}

--- a/presentation/src/main/java/com/umc/presentation/ui/act/adapter/ChallengerInfoHistoryAdapter.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/act/adapter/ChallengerInfoHistoryAdapter.kt
@@ -5,10 +5,10 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
-import com.umc.domain.model.act.challenger.SimpleHistoryItem
+import com.umc.domain.model.act.challenger.ChallengerInfoHistory
 import com.umc.presentation.databinding.ItemChallengerHistoryCheckBinding
 
-class ChallengerInfoHistoryAdapter : ListAdapter<SimpleHistoryItem, ChallengerInfoHistoryAdapter.ViewHolder>(DiffCallback()) {
+class ChallengerInfoHistoryAdapter : ListAdapter<ChallengerInfoHistory, ChallengerInfoHistoryAdapter.ViewHolder>(DiffCallback()) {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
         val binding = ItemChallengerHistoryCheckBinding.inflate(
@@ -23,14 +23,14 @@ class ChallengerInfoHistoryAdapter : ListAdapter<SimpleHistoryItem, ChallengerIn
 
     class ViewHolder(private val binding: ItemChallengerHistoryCheckBinding) :
         RecyclerView.ViewHolder(binding.root) {
-        fun bind(item: SimpleHistoryItem) {
+        fun bind(item: ChallengerInfoHistory) {
             binding.item = item
             binding.executePendingBindings()
         }
     }
 
-    class DiffCallback : DiffUtil.ItemCallback<SimpleHistoryItem>() {
-        override fun areItemsTheSame(oldItem: SimpleHistoryItem, newItem: SimpleHistoryItem) = oldItem.title == newItem.title
-        override fun areContentsTheSame(oldItem: SimpleHistoryItem, newItem: SimpleHistoryItem) = oldItem == newItem
+    class DiffCallback : DiffUtil.ItemCallback<ChallengerInfoHistory>() {
+        override fun areItemsTheSame(oldItem: ChallengerInfoHistory, newItem: ChallengerInfoHistory) = oldItem.title == newItem.title
+        override fun areContentsTheSame(oldItem: ChallengerInfoHistory, newItem: ChallengerInfoHistory) = oldItem == newItem
     }
 }

--- a/presentation/src/main/java/com/umc/presentation/ui/act/challenge/AdminChallengerFragment.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/act/challenge/AdminChallengerFragment.kt
@@ -2,19 +2,18 @@ package com.umc.presentation.ui.act.challenge
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import android.widget.Toast
 import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.ConcatAdapter
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
-import com.umc.domain.model.act.challenger.AdminChallenger
+import com.umc.domain.model.act.challenger.ChallengerInfoDialogModel
 import com.umc.domain.model.enums.UserPart
 import com.umc.presentation.R
 import com.umc.presentation.base.BaseFragment
-import com.umc.domain.model.act.challenger.HistoryItem
-import com.umc.domain.model.act.challenger.HistoryType
 import com.umc.presentation.component.UBasicDialog
 import com.umc.presentation.component.UBasicDialogModel
-import com.umc.domain.model.act.challenger.UChallengerManageDialogModel
+import com.umc.domain.model.act.challenger.ChallengerManageDialogModel
 import com.umc.presentation.databinding.FragmentAdminChallengerBinding
 import com.umc.presentation.extension.px
 import com.umc.presentation.ui.act.adapter.ChallengerHeaderAdapter
@@ -54,7 +53,7 @@ class AdminChallengerFragment : BaseFragment<FragmentAdminChallengerBinding, Adm
             val headerAdapter = ChallengerHeaderAdapter(part.label)
 
             val itemAdapter = AdminChallengerAdapter { challenger ->
-                showManageDialog(challenger)
+                viewModel.onChallengerClicked(challenger.id)
             }
 
             headerAdapters[part] = headerAdapter
@@ -83,45 +82,6 @@ class AdminChallengerFragment : BaseFragment<FragmentAdminChallengerBinding, Adm
         }
     }
 
-    /**
-     * 다이얼로그에 더미 데이터 추가 (연동할 때 변경 예정)
-     */
-    private fun showManageDialog(challenger: AdminChallenger) {
-        val dialogModel = UChallengerManageDialogModel(
-            name = challenger.name,
-            university = "중앙대학교",
-            part = challenger.part.label,
-            absenceCount = challenger.outCount,
-            warningCount = challenger.warningCount,
-            hasNewAbsence = false,
-            history = listOf(
-                HistoryItem("2024.01.01", "스터디 미제출", HistoryType.OUT, 1.0),
-                HistoryItem("2024.01.01", "세션 지각", HistoryType.WARNING, 0.5)
-            )
-        )
-
-        val dialog = ChallengerManageDialog(
-            model = dialogModel,
-            onAbsenceSubmit = { reason -> /* TODO: API 연동 */ },
-            onWarningSubmit = { reason -> /* TODO: API 연동 */ },
-            onDeleteHistory = { item ->
-                val warningDialog = UBasicDialog(
-                    model = UBasicDialogModel.Warning(
-                        title = "해당 기록을 삭제하시겠습니까?",
-                        content = "삭제된 기록은 복구가 어렵습니다.",
-                        positiveText = "삭제하기"
-                    ),
-                    onConfirm = {
-                        /* TODO: API 연동 */
-                    }
-                )
-                warningDialog.show(childFragmentManager, "DeleteWarningDialog")
-            }
-        )
-
-        dialog.show(childFragmentManager, "UChallengerManageDialog")
-    }
-
     override fun initStates() {
         repeatOnStarted(viewLifecycleOwner) {
             launch {
@@ -134,6 +94,38 @@ class AdminChallengerFragment : BaseFragment<FragmentAdminChallengerBinding, Adm
                     }
                 }
             }
+            launch { viewModel.uiEvent.collect { handleEvent(it) } }
         }
+    }
+
+    override fun handleEvent(event: AdminChallengerEvent) {
+        when (event) {
+            is AdminChallengerEvent.ShowManageDialog -> {
+                showManageDialog(event.model)
+            }
+            is AdminChallengerEvent.ShowErrorToast -> {
+                Toast.makeText(requireContext(), event.message, Toast.LENGTH_SHORT).show()
+            }
+        }
+    }
+
+    private fun showManageDialog(model: ChallengerManageDialogModel) {
+        val dialog = ChallengerManageDialog(
+            model = model,
+            onAbsenceSubmit = { reason -> /* TODO */ },
+            onWarningSubmit = { reason -> /* TODO */ },
+            onDeleteHistory = { item ->
+                val warningDialog = UBasicDialog(
+                    model = UBasicDialogModel.Warning(
+                        title = "해당 기록을 삭제하시겠습니까?",
+                        content = "삭제된 기록은 복구가 어렵습니다.",
+                        positiveText = "삭제하기"
+                    ),
+                    onConfirm = { /* TODO */ }
+                )
+                warningDialog.show(childFragmentManager, "DeleteWarningDialog")
+            }
+        )
+        dialog.show(childFragmentManager, "UChallengerManageDialog")
     }
 }

--- a/presentation/src/main/java/com/umc/presentation/ui/act/challenge/AdminChallengerViewModel.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/act/challenge/AdminChallengerViewModel.kt
@@ -1,25 +1,31 @@
 package com.umc.presentation.ui.act.challenge
 
+import androidx.lifecycle.viewModelScope
 import com.umc.domain.model.act.challenger.AdminChallenger
+import com.umc.domain.model.act.challenger.ChallengerManageDialogModel
+import com.umc.domain.model.base.ApiState
 import com.umc.domain.model.enums.UserPart
+import com.umc.domain.usecase.GetAdminChallengerDetailUseCase
 import com.umc.presentation.base.BaseViewModel
 import com.umc.presentation.base.UiEvent
 import com.umc.presentation.base.UiState
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-class AdminChallengerViewModel @Inject constructor() :
-    BaseViewModel<AdminChallengerUiState, AdminChallengerEvent>(AdminChallengerUiState()) {
+class AdminChallengerViewModel @Inject constructor(
+    private val getAdminChallengerDetailUseCase: GetAdminChallengerDetailUseCase
+) : BaseViewModel<AdminChallengerUiState, AdminChallengerEvent>(AdminChallengerUiState()) {
 
     init { loadInitialData() }
 
     private fun loadInitialData() {
         val dummyList = listOf(
-            AdminChallenger(1, "김디자", "닉네임1", 12, UserPart.DESIGN, outCount = 1, warningCount = 0),
-            AdminChallenger(2, "홍길동", "닉네임2", 12, UserPart.PM, outCount = 0, warningCount = 1),
-            AdminChallenger(3, "이웹마", "닉네임3", 12, UserPart.WEB, outCount = 2, warningCount = 1),
-            AdminChallenger(4, "박안드", "닉네임4", 12, UserPart.ANDROID, outCount = 0, warningCount = 0)
+            AdminChallenger(101, "김디자", "닉네임1", 12, UserPart.DESIGN, outCount = 1, warningCount = 0),
+            AdminChallenger(102, "홍길동", "닉네임2", 12, UserPart.PM, outCount = 0, warningCount = 1),
+            AdminChallenger(103, "이웹마", "닉네임3", 12, UserPart.WEB, outCount = 2, warningCount = 1),
+            AdminChallenger(104, "박안드", "닉네임4", 12, UserPart.ANDROID, outCount = 0, warningCount = 0)
         )
         updateState { copy(allChallengers = dummyList, filteredChallengers = dummyList) }
     }
@@ -30,6 +36,20 @@ class AdminChallengerViewModel @Inject constructor() :
         }
         updateState { copy(filteredChallengers = filtered) }
     }
+
+    // 상세 정보 API 호출 함수
+    fun onChallengerClicked(id: Int) {
+        viewModelScope.launch {
+            when (val result = getAdminChallengerDetailUseCase(id.toLong())) {
+                is ApiState.Success -> {
+                    emitEvent(AdminChallengerEvent.ShowManageDialog(result.data))
+                }
+                is ApiState.Fail -> {
+                    emitEvent(AdminChallengerEvent.ShowErrorToast(result.failState.message))
+                }
+            }
+        }
+    }
 }
 
 data class AdminChallengerUiState(
@@ -37,6 +57,7 @@ data class AdminChallengerUiState(
     val filteredChallengers: List<AdminChallenger> = emptyList()
 ) : UiState
 
-sealed class AdminChallengerEvent : UiEvent {
-    data class NavigateToDetail(val id: Int) : AdminChallengerEvent()
+sealed interface AdminChallengerEvent : UiEvent {
+    data class ShowManageDialog(val model: ChallengerManageDialogModel) : AdminChallengerEvent
+    data class ShowErrorToast(val message: String) : AdminChallengerEvent
 }

--- a/presentation/src/main/java/com/umc/presentation/ui/act/challenge/ChallengerManageDialog.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/act/challenge/ChallengerManageDialog.kt
@@ -13,12 +13,12 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import com.umc.presentation.R
 import com.umc.domain.model.act.challenger.HistoryItem
 import com.umc.presentation.component.UButton
-import com.umc.domain.model.act.challenger.UChallengerManageDialogModel
+import com.umc.domain.model.act.challenger.ChallengerManageDialogModel
 import com.umc.presentation.databinding.DialogChallengerManageBinding
 import com.umc.presentation.ui.act.adapter.ChallengerHistoryAdapter
 
 class ChallengerManageDialog(
-    private val model: UChallengerManageDialogModel,
+    private val model: ChallengerManageDialogModel,
     private val onAbsenceSubmit: (String) -> Unit = {},
     private val onWarningSubmit: (String) -> Unit = {},
     private val onDeleteHistory: (HistoryItem) -> Unit = {}

--- a/presentation/src/main/java/com/umc/presentation/ui/act/challenge/UserChallengerFragment.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/act/challenge/UserChallengerFragment.kt
@@ -2,6 +2,7 @@ package com.umc.presentation.ui.act.challenge
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import android.widget.Toast
 import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.ConcatAdapter
 import androidx.recyclerview.widget.RecyclerView
@@ -97,6 +98,9 @@ class UserChallengerFragment : BaseFragment<FragmentUserChallengerBinding, UserC
         when (event) {
             is UserChallengerEvent.NavigateToDetail -> {
                 ChallengerInfoDialog(event.model).show(childFragmentManager, "ChallengerInfoDialog")
+            }
+            is UserChallengerEvent.ShowErrorToast -> {
+                Toast.makeText(requireContext(), event.message, Toast.LENGTH_SHORT).show()
             }
         }
     }

--- a/presentation/src/main/java/com/umc/presentation/ui/act/challenge/UserChallengerFragment.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/act/challenge/UserChallengerFragment.kt
@@ -4,10 +4,9 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.ConcatAdapter
-import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.umc.domain.model.act.challenger.ChallengerInfoDialogModel
-import com.umc.domain.model.act.challenger.SimpleHistoryItem
+import com.umc.domain.model.act.challenger.ChallengerInfoHistory
 import com.umc.domain.model.enums.CheckHistoryStatus
 import com.umc.domain.model.enums.UserPart
 import com.umc.presentation.R
@@ -91,27 +90,13 @@ class UserChallengerFragment : BaseFragment<FragmentUserChallengerBinding, UserC
         }
     }
 
+    /**
+     * ViewModel에서 발생한 이벤트를 처리
+     */
     override fun handleEvent(event: UserChallengerEvent) {
         when (event) {
             is UserChallengerEvent.NavigateToDetail -> {
-                val challenger = viewModel.uiState.value.allChallengers.find { it.id == event.id }
-
-                challenger?.let { data ->
-                    val infoModel = ChallengerInfoDialogModel(
-                        name = data.name,
-                        university = "중앙대학교",
-                        part = data.part.label,
-                        generation = "12기",
-                        warningCount = 1.0,
-                        history = listOf(
-                            SimpleHistoryItem("3주차 정기 세션", CheckHistoryStatus.SUCCESS),
-                            SimpleHistoryItem("2주차 정기 세션", CheckHistoryStatus.LATE),
-                            SimpleHistoryItem("1주차 정기 세션", CheckHistoryStatus.ABSENT)
-                        )
-                    )
-
-                    ChallengerInfoDialog(infoModel).show(childFragmentManager, "ChallengerInfoDialog")
-                }
+                ChallengerInfoDialog(event.model).show(childFragmentManager, "ChallengerInfoDialog")
             }
         }
     }

--- a/presentation/src/main/java/com/umc/presentation/ui/act/challenge/UserChallengerViewModel.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/act/challenge/UserChallengerViewModel.kt
@@ -24,8 +24,8 @@ class UserChallengerViewModel @Inject constructor(
     private fun loadInitialData() {
         val dummyList = listOf(
             // PM 파트
-            UserChallenger(1, "김유엠", "유엠씨대장", 12, UserPart.PM, UserChallengerRole.LEADER),
-            UserChallenger(2, "이길동", "피엠조아", 12, UserPart.PM, UserChallengerRole.MEMBER),
+            UserChallenger(101, "김유엠", "유엠씨대장", 12, UserPart.PM, UserChallengerRole.LEADER),
+            UserChallenger(102, "이길동", "피엠조아", 12, UserPart.PM, UserChallengerRole.MEMBER),
 
             // Design 파트
             UserChallenger(3, "박디자인", "피그마마스터", 12, UserPart.DESIGN, UserChallengerRole.PART_LEADER),

--- a/presentation/src/main/java/com/umc/presentation/ui/act/challenge/UserChallengerViewModel.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/act/challenge/UserChallengerViewModel.kt
@@ -66,16 +66,13 @@ class UserChallengerViewModel @Inject constructor(
 
     fun navigateToDetail(id: Int) {
         viewModelScope.launch {
-            try {
-                when (val result = getChallengerDetailUseCase(id.toLong())) {
-                    is ApiState.Success -> {
-                        emitEvent(UserChallengerEvent.NavigateToDetail(result.data))
-                    }
-                    is ApiState.Fail -> {
-                    }
+            when (val result = getChallengerDetailUseCase(id.toLong())) {
+                is ApiState.Success -> {
+                    emitEvent(UserChallengerEvent.NavigateToDetail(result.data))
                 }
-            } catch (e: Exception) {
-                e.printStackTrace()
+                is ApiState.Fail -> {
+                    emitEvent(UserChallengerEvent.ShowErrorToast(result.failState.message))
+                }
             }
         }
     }
@@ -86,6 +83,7 @@ data class UserChallengerUiState(
     val filteredChallengers: List<UserChallenger> = emptyList()
 ) : UiState
 
-sealed class UserChallengerEvent : UiEvent {
-    data class NavigateToDetail(val model: ChallengerInfoDialogModel) : UserChallengerEvent()
+sealed interface UserChallengerEvent : UiEvent {
+    data class NavigateToDetail(val model: ChallengerInfoDialogModel) : UserChallengerEvent
+    data class ShowErrorToast(val message: String) : UserChallengerEvent
 }

--- a/presentation/src/main/java/com/umc/presentation/ui/act/challenge/UserChallengerViewModel.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/act/challenge/UserChallengerViewModel.kt
@@ -1,17 +1,23 @@
 package com.umc.presentation.ui.act.challenge
 
+import androidx.lifecycle.viewModelScope
+import com.umc.domain.model.act.challenger.ChallengerInfoDialogModel
 import com.umc.domain.model.act.challenger.UserChallenger
+import com.umc.domain.model.base.ApiState
 import com.umc.domain.model.enums.UserChallengerRole
 import com.umc.domain.model.enums.UserPart
+import com.umc.domain.usecase.GetChallengerDetailUseCase
 import com.umc.presentation.base.BaseViewModel
 import com.umc.presentation.base.UiEvent
 import com.umc.presentation.base.UiState
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-class UserChallengerViewModel @Inject constructor() :
-    BaseViewModel<UserChallengerUiState, UserChallengerEvent>(UserChallengerUiState()) {
+class UserChallengerViewModel @Inject constructor(
+    private val getChallengerDetailUseCase: GetChallengerDetailUseCase
+) : BaseViewModel<UserChallengerUiState, UserChallengerEvent>(UserChallengerUiState()) {
 
     init { loadInitialData() }
 
@@ -59,7 +65,19 @@ class UserChallengerViewModel @Inject constructor() :
     }
 
     fun navigateToDetail(id: Int) {
-        emitEvent(UserChallengerEvent.NavigateToDetail(id))
+        viewModelScope.launch {
+            try {
+                when (val result = getChallengerDetailUseCase(id.toLong())) {
+                    is ApiState.Success -> {
+                        emitEvent(UserChallengerEvent.NavigateToDetail(result.data))
+                    }
+                    is ApiState.Fail -> {
+                    }
+                }
+            } catch (e: Exception) {
+                e.printStackTrace()
+            }
+        }
     }
 }
 
@@ -69,5 +87,5 @@ data class UserChallengerUiState(
 ) : UiState
 
 sealed class UserChallengerEvent : UiEvent {
-    data class NavigateToDetail(val id: Int) : UserChallengerEvent()
+    data class NavigateToDetail(val model: ChallengerInfoDialogModel) : UserChallengerEvent()
 }

--- a/presentation/src/main/res/layout/dialog_challenger_info.xml
+++ b/presentation/src/main/res/layout/dialog_challenger_info.xml
@@ -4,6 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <data>
+        <import type="android.view.View" />
         <variable
             name="model"
             type="com.umc.domain.model.act.challenger.ChallengerInfoDialogModel" />
@@ -208,9 +209,40 @@
                 android:layout_marginTop="8dp"
                 android:background="@drawable/bg_rectangle_neutral000_stroke_neutral300_radius8"
                 android:padding="16dp"
+                android:visibility="@{model.history.empty ? View.GONE : View.VISIBLE}"
                 app:layout_constraintTop_toBottomOf="@id/tv_history_label"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintEnd_toEndOf="parent" />
+
+            <LinearLayout
+                android:id="@+id/layout_empty_history"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:background="@drawable/bg_rectangle_neutral000_stroke_neutral300_radius8"
+                android:gravity="center"
+                android:orientation="vertical"
+                android:paddingVertical="40dp"
+                android:visibility="@{model.history.empty ? View.VISIBLE : View.GONE}"
+                app:layout_constraintTop_toBottomOf="@id/tv_history_label"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent">
+
+                <ImageView
+                    android:layout_width="24dp"
+                    android:layout_height="24dp"
+                    android:src="@drawable/ic_history"
+                    app:tint="@color/neutral500" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp"
+                    android:text="아직 활동 기록이 없습니다"
+                    android:textAppearance="@style/Caption1Bold"
+                    android:textColor="@color/neutral500" />
+            </LinearLayout>
+
         </androidx.constraintlayout.widget.ConstraintLayout>
 
     </androidx.constraintlayout.widget.ConstraintLayout>

--- a/presentation/src/main/res/layout/dialog_challenger_info.xml
+++ b/presentation/src/main/res/layout/dialog_challenger_info.xml
@@ -133,12 +133,12 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="8dp"
-                    tools:text="12기"
-                    android:text="@{model.generation}"
+                    android:text="@{@string/challenger_info_format_generation(model.generation)}"
                     android:textAppearance="@style/HeadlineBold"
                     app:layout_constraintTop_toBottomOf="@id/tv_gen_label"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintEnd_toEndOf="parent" />
+                    app:layout_constraintEnd_toEndOf="parent"
+                    tools:text="12기" />
             </androidx.constraintlayout.widget.ConstraintLayout>
 
             <androidx.constraintlayout.widget.ConstraintLayout

--- a/presentation/src/main/res/layout/dialog_challenger_manage.xml
+++ b/presentation/src/main/res/layout/dialog_challenger_manage.xml
@@ -7,7 +7,7 @@
         <import type="android.view.View" />
         <variable
             name="model"
-            type="com.umc.domain.model.act.challenger.UChallengerManageDialogModel" />
+            type="com.umc.domain.model.act.challenger.ChallengerManageDialogModel" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -349,9 +349,39 @@
                 android:layout_marginTop="8dp"
                 android:background="@drawable/bg_rectangle_neutral000_stroke_neutral300_radius8"
                 android:padding="16dp"
+                android:visibility="@{model.history.empty ? View.GONE : View.VISIBLE}"
                 app:layout_constraintTop_toBottomOf="@id/tv_history_label"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintEnd_toEndOf="parent" />
+
+            <LinearLayout
+                android:id="@+id/layout_empty_history"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:background="@drawable/bg_rectangle_neutral000_stroke_neutral300_radius8"
+                android:gravity="center"
+                android:orientation="vertical"
+                android:paddingVertical="30dp"
+                android:visibility="@{model.history.empty ? View.VISIBLE : View.GONE}"
+                app:layout_constraintTop_toBottomOf="@id/tv_history_label"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent">
+
+                <ImageView
+                    android:layout_width="24dp"
+                    android:layout_height="24dp"
+                    android:src="@drawable/ic_history"
+                    app:tint="@color/neutral500" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp"
+                    android:text="아직 활동 기록이 없습니다"
+                    android:textAppearance="@style/Caption1Bold"
+                    android:textColor="@color/neutral500" />
+            </LinearLayout>
         </androidx.constraintlayout.widget.ConstraintLayout>
 
     </androidx.constraintlayout.widget.ConstraintLayout>

--- a/presentation/src/main/res/layout/item_challenger_history_check.xml
+++ b/presentation/src/main/res/layout/item_challenger_history_check.xml
@@ -6,7 +6,7 @@
     <data>
         <variable
             name="item"
-            type="com.umc.domain.model.act.challenger.SimpleHistoryItem" />
+            type="com.umc.domain.model.act.challenger.ChallengerInfoHistory" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -259,6 +259,7 @@
     <string name="challenger_info_generation_label">활동 기수</string>
     <string name="challenger_info_warning_label">누적 경고</string>
     <string name="challenger_info_history_label">출석/활동 기록</string>
+    <string name="challenger_info_format_generation">%d기</string>
 
     <string name="challenger_manage_history_title">히스토리</string>
     <string name="challenger_manage_delete_guide">삭제 버튼을 눌러 기록을 삭제할 수 있습니다.</string>


### PR DESCRIPTION
## #️⃣ 이슈 번호

> 관련된 이슈 번호를 적어주세요.\
> Close #57 

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 요약해주세요.

- 챌린지 정보 조회 API 연동을 진행했습니다.
- 챌린저의 출석/활동 내역이 없을 시의 디자인을 추가하였습니다.
- 현재 서버 응답에서 일부 필드(name, university 등)가 null로 내려오는 문제를 확인하여, 도메인 모델 변환 시 기본값을 "알수없음"으로 처리하도록 했습니다.

## 📸 스크린샷 (선택 사항)
| 챌린저 정보 조회 API | 없는 유저 선택 |
| :---: | :---: |
| <img width="250" alt="image" src="https://github.com/user-attachments/assets/572462db-1e31-44c8-8caf-3454be86ec2b" /> | <img width="250" alt="image" src="https://github.com/user-attachments/assets/c46d9821-fc6a-4855-8b6d-c52b758e1ed0" /> |

## 🚩 리뷰 요구사항
> 리뷰어가 중점적으로 봐주었으면 하는 부분이 있다면 작성해주세요.

- DataSource 구조 관련: 경석님(Auth)의 ApiState 구조를 참고했으나, Retrofit 반환 타입 설정 시 JsonIOException이 발생하여 현재는 DataSource에서 직접 try-catch로 래핑하고 있습니다. 이 방식이 팀 컨벤션에 부합하는지, 혹은 네트워크 모듈(AuthNetworkModule) 수정이 필요한지 검토 부탁드립니다.
- 에러 응답 파싱: 서버에서 에러 발생 시 보내주는 JSON 바디(code, message)를 ApiState.Fail에 담아 토스트로 띄우고 있는데, 이 흐름이 적절한지 봐주시면 감사하겠습니다.

## 🏁 체크리스트
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 로그나 주석을 제거했나요?
- [x] 머지 대상 브랜치(Base branch)가 올바른가요?
