### PR TITLE
[fix/#58] - mapSuccessData 제거 / apiCall 추가

### DIFF
--- a/data/src/main/java/com/umc/data/dataSource/base/ApiCall.kt
+++ b/data/src/main/java/com/umc/data/dataSource/base/ApiCall.kt
@@ -1,0 +1,46 @@
+package com.umc.data.dataSource.base
+
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+import com.umc.domain.model.base.ApiResponse
+import com.umc.domain.model.base.ApiState
+import com.umc.domain.model.base.FailState
+import retrofit2.HttpException
+
+suspend inline fun <reified T> apiCall(
+    crossinline apiCall: suspend () -> ApiResponse<T>
+): ApiState<T> {
+    return try {
+        val response = apiCall()
+
+        if (response.result != null) {
+            ApiState.Success(response.result)
+        } else {
+            ApiState.Fail(
+                FailState(success = false, code = response.code, message = "null")
+            )
+        }
+
+    } catch (e: HttpException) {
+        //TODO 공통 에러
+        val errorBodyStr = e.response()?.errorBody()?.string()
+        val type = object : TypeToken<ApiResponse<T>>() {}.type
+
+        val errorResponse: ApiResponse<T>? = try {
+            Gson().fromJson(errorBodyStr, type)
+        } catch (parseException: Exception) {
+            null
+        }
+
+        val code = errorResponse?.code ?: e.code().toString()
+        val message = errorResponse?.message ?: e.message()
+
+        ApiState.Fail(FailState(success = false, code = code, message = message))
+
+    } catch (e: Exception) {
+        e.printStackTrace()
+        ApiState.Fail(
+            FailState(success = false, code = "400", message = e.message ?: "Unknown Error")
+        )
+    } as ApiState<T>
+}

--- a/data/src/main/java/com/umc/data/dataSource/remote/ChallengerRemoteDataSourceImpl.kt
+++ b/data/src/main/java/com/umc/data/dataSource/remote/ChallengerRemoteDataSourceImpl.kt
@@ -26,7 +26,7 @@ class ChallengerRemoteDataSourceImpl @Inject constructor(
             val errorResponse = Gson().fromJson(errorBody, ApiResponse::class.java)
 
             ApiState.Fail(FailState(
-                isSuccess = false,
+                success = false,
                 code = errorResponse?.code ?: "HTTP_${e.code()}",
                 message = errorResponse?.message ?: "서버 에러가 발생했습니다."
             ))

--- a/data/src/main/java/com/umc/data/dataSource/remote/member/MemberRemoteDataSourceImpl.kt
+++ b/data/src/main/java/com/umc/data/dataSource/remote/member/MemberRemoteDataSourceImpl.kt
@@ -1,6 +1,7 @@
 package com.umc.data.dataSource.remote.member
 
 import com.umc.data.api.MemberApi
+import com.umc.data.dataSource.base.apiCall
 import com.umc.data.response.member.MemberResponse
 import com.umc.domain.model.base.ApiResponse
 import com.umc.domain.model.base.ApiState
@@ -14,6 +15,10 @@ class MemberRemoteDataSourceImpl @Inject constructor(
     override suspend fun getMyProfile(): ApiState<MemberResponse> = fetch {
         memberApi.getMyProfile()
     }.mapSuccessData()
+
+//    override suspend fun getMyProfile(): ApiState<MemberResponse> {
+//        return apiCall { memberApi.getMyProfile() }
+//    }
 
 
     override suspend fun getMemberProfile(id: Long): ApiState<MemberResponse> = fetch {

--- a/domain/src/main/java/com/umc/domain/model/base/ApiState.kt
+++ b/domain/src/main/java/com/umc/domain/model/base/ApiState.kt
@@ -22,12 +22,8 @@ fun <T> ApiState<ApiResponse<T>>.mapSuccessData() : ApiState<T> {
     }
 }
 
-fun <T> ApiResponse<T>.mapSuccessData() : ApiState<T> {
-    return if (this.success) ApiState.Success(this.result ?: (Unit as T)) else ApiState.Fail(FailState.default)
-}
-
 data class FailState(
-    val success: Boolean,
+    val success: Boolean = false,
     val code: String,
     val message: String
 ) {


### PR DESCRIPTION
## #️⃣ 이슈 번호

> 관련된 이슈 번호를 적어주세요.\
> Close #58 

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 요약해주세요.

mapSuccessData 날려버렸습니다. 이거는 이제 신경쓰지 마시고

```
    override suspend fun getMyProfile(): ApiState<MemberResponse> {
        return apiCall { memberApi.getMyProfile() }
    }

```
처럼 함수를 이용하시면 되겠습니다. api는  `ApiResponse<MemberResponse>` 으로 반환 타입 동일합니다.

## 📸 스크린샷 (선택 사항)
| 설명 | 이미지 |
| :---: | :---: |
|  |  |

## 🚩 리뷰 요구사항
> 리뷰어가 중점적으로 봐주었으면 하는 부분이 있다면 작성해주세요.

## 🏁 체크리스트
- [ ] 코딩 컨벤션을 준수했나요?
- [ ] 불필요한 로그나 주석을 제거했나요?
- [ ] 머지 대상 브랜치(Base branch)가 올바른가요?
