### PR TITLE
[Feat/#65] 출석 가능한 세션 관련 API 연동

### DIFF
--- a/app/src/main/java/com/umc/product/di/ApiModule.kt
+++ b/app/src/main/java/com/umc/product/di/ApiModule.kt
@@ -1,5 +1,6 @@
 package com.umc.product.di
 
+import com.umc.data.api.AttendanceApi
 import com.umc.data.api.AuthApi
 import com.umc.data.api.MemberApi
 import com.umc.data.api.ChallengerApi
@@ -33,5 +34,11 @@ object ApiModule {
     @Provides
     fun provideChallengerApi(@AuthRetrofit retrofit: Retrofit): ChallengerApi {
         return retrofit.create(ChallengerApi::class.java)
+    }
+
+    @Singleton
+    @Provides
+    fun provideAttendanceApi(@AuthRetrofit retrofit: Retrofit): AttendanceApi {
+        return retrofit.create(AttendanceApi::class.java)
     }
 }

--- a/app/src/main/java/com/umc/product/di/ApiModule.kt
+++ b/app/src/main/java/com/umc/product/di/ApiModule.kt
@@ -4,6 +4,7 @@ import com.umc.data.api.AttendanceApi
 import com.umc.data.api.AuthApi
 import com.umc.data.api.MemberApi
 import com.umc.data.api.ChallengerApi
+import com.umc.data.api.ScheduleApi
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -40,5 +41,11 @@ object ApiModule {
     @Provides
     fun provideAttendanceApi(@AuthRetrofit retrofit: Retrofit): AttendanceApi {
         return retrofit.create(AttendanceApi::class.java)
+    }
+
+    @Singleton
+    @Provides
+    fun provideScheduleApi(@AuthRetrofit retrofit: Retrofit): ScheduleApi {
+        return retrofit.create(ScheduleApi::class.java)
     }
 }

--- a/app/src/main/java/com/umc/product/di/AuthenticationInterceptor.kt
+++ b/app/src/main/java/com/umc/product/di/AuthenticationInterceptor.kt
@@ -13,7 +13,7 @@ class AuthenticationInterceptor
     constructor() : Interceptor {
         override fun intercept(chain: Interceptor.Chain): Response {
             // val accessToken = runBlocking { repository.getAccessToken().first() }
-            val testToken = "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxMDMiLCJpYXQiOjE3NzAyNjM4OTEsImV4cCI6MTc3MDI2NzQ5MX0.FGdg0Ryql8oZPEDCueKZfMkhc0ZyLXi49gf_TQNN4VVIpAl6lG9awskIiuCbgroWMAUWDv-tElpR7TFHi6NdiQ"
+            val testToken = "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxMDEiLCJpYXQiOjE3NzAzNzIwNjMsImV4cCI6MTc3MDM3NTY2M30.eCotJy0m-KKqyQ2RdGID7ojb7NnF8saBYkgwblLJJesgY72nM-yTGp0Ys53ZerGN13pnZcQt-ypTCSwTuYTdnw"
 
             val request =
                 chain.request().newBuilder()

--- a/app/src/main/java/com/umc/product/di/DataSourceModule.kt
+++ b/app/src/main/java/com/umc/product/di/DataSourceModule.kt
@@ -1,13 +1,13 @@
 package com.umc.product.di
 
 import com.umc.data.dataSource.AuthRemoteDataSource
-import com.umc.data.dataSource.ChallengerRemoteDataSource
+import com.umc.data.dataSource.remote.challenger.ChallengerRemoteDataSource
 import com.umc.data.dataSource.remote.AuthRemoteDataSourceImpl
 import com.umc.data.dataSource.remote.kakao.KakaoRemoteDataSource
 import com.umc.data.dataSource.remote.kakao.KakaoRemoteDataSourceImpl
 import com.umc.data.dataSource.remote.member.MemberRemoteDataSource
 import com.umc.data.dataSource.remote.member.MemberRemoteDataSourceImpl
-import com.umc.data.dataSource.remote.ChallengerRemoteDataSourceImpl
+import com.umc.data.dataSource.remote.challenger.ChallengerRemoteDataSourceImpl
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn

--- a/app/src/main/java/com/umc/product/di/DataSourceModule.kt
+++ b/app/src/main/java/com/umc/product/di/DataSourceModule.kt
@@ -3,6 +3,8 @@ package com.umc.product.di
 import com.umc.data.dataSource.AuthRemoteDataSource
 import com.umc.data.dataSource.remote.challenger.ChallengerRemoteDataSource
 import com.umc.data.dataSource.remote.AuthRemoteDataSourceImpl
+import com.umc.data.dataSource.remote.attendance.AttendanceRemoteDataSource
+import com.umc.data.dataSource.remote.attendance.AttendanceRemoteDataSourceImpl
 import com.umc.data.dataSource.remote.kakao.KakaoRemoteDataSource
 import com.umc.data.dataSource.remote.kakao.KakaoRemoteDataSourceImpl
 import com.umc.data.dataSource.remote.member.MemberRemoteDataSource
@@ -43,4 +45,8 @@ abstract class DataSourceModule {
     @Singleton
     @Binds
     abstract fun bindsChallengerRemoteDataSource(dataSourceImpl: ChallengerRemoteDataSourceImpl): ChallengerRemoteDataSource
+
+    @Singleton
+    @Binds
+    abstract fun bindsAttendanceRemoteDataSource(dataSourceImpl: AttendanceRemoteDataSourceImpl): AttendanceRemoteDataSource
 }

--- a/app/src/main/java/com/umc/product/di/DataSourceModule.kt
+++ b/app/src/main/java/com/umc/product/di/DataSourceModule.kt
@@ -10,6 +10,8 @@ import com.umc.data.dataSource.remote.kakao.KakaoRemoteDataSourceImpl
 import com.umc.data.dataSource.remote.member.MemberRemoteDataSource
 import com.umc.data.dataSource.remote.member.MemberRemoteDataSourceImpl
 import com.umc.data.dataSource.remote.challenger.ChallengerRemoteDataSourceImpl
+import com.umc.data.dataSource.remote.schedule.ScheduleRemoteDataSource
+import com.umc.data.dataSource.remote.schedule.ScheduleRemoteDataSourceImpl
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -49,4 +51,8 @@ abstract class DataSourceModule {
     @Singleton
     @Binds
     abstract fun bindsAttendanceRemoteDataSource(dataSourceImpl: AttendanceRemoteDataSourceImpl): AttendanceRemoteDataSource
+
+    @Singleton
+    @Binds
+    abstract fun bindsScheduleRemoteDataSource(dataSourceImpl: ScheduleRemoteDataSourceImpl): ScheduleRemoteDataSource
 }

--- a/app/src/main/java/com/umc/product/di/RepositoryModule.kt
+++ b/app/src/main/java/com/umc/product/di/RepositoryModule.kt
@@ -3,6 +3,7 @@ package com.umc.product.di
 import com.umc.data.repository.AppDataStoreRepositoryImpl
 import com.umc.domain.repository.AppDataStoreRepository
 import com.umc.data.repository.AuthRepositoryImpl
+import com.umc.data.repository.attendance.AttendanceRepositoryImpl
 import com.umc.data.repository.kakao.KakaoSearchRepositoryImpl
 import com.umc.data.repository.member.MemberRepositoryImpl
 import com.umc.domain.repository.AuthRepository
@@ -10,6 +11,7 @@ import com.umc.domain.repository.kakao.KakaoSearchRepository
 import com.umc.domain.repository.member.MemberRepository
 import com.umc.data.repository.challenger.ChallengerRepositoryImpl
 import com.umc.domain.repository.ChallengerRepository
+import com.umc.domain.repository.attendance.AttendanceRepository
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -55,4 +57,9 @@ abstract class RepositoryModule {
     @Singleton
     @Binds
     abstract fun bindsChallengerRepository(repositoryImpl: ChallengerRepositoryImpl): ChallengerRepository
+
+    @Singleton
+    @Binds
+    abstract fun bindsAttendanceRepository(repositoryImpl: AttendanceRepositoryImpl): AttendanceRepository
+
 }

--- a/app/src/main/java/com/umc/product/di/RepositoryModule.kt
+++ b/app/src/main/java/com/umc/product/di/RepositoryModule.kt
@@ -10,8 +10,10 @@ import com.umc.domain.repository.AuthRepository
 import com.umc.domain.repository.kakao.KakaoSearchRepository
 import com.umc.domain.repository.member.MemberRepository
 import com.umc.data.repository.challenger.ChallengerRepositoryImpl
+import com.umc.data.repository.schedule.ScheduleRepositoryImpl
 import com.umc.domain.repository.ChallengerRepository
 import com.umc.domain.repository.attendance.AttendanceRepository
+import com.umc.domain.repository.schedule.ScheduleRepository
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -61,5 +63,9 @@ abstract class RepositoryModule {
     @Singleton
     @Binds
     abstract fun bindsAttendanceRepository(repositoryImpl: AttendanceRepositoryImpl): AttendanceRepository
+
+    @Singleton
+    @Binds
+    abstract fun bindsScheduleRepository(repositoryImpl: ScheduleRepositoryImpl): ScheduleRepository
 
 }

--- a/app/src/main/java/com/umc/product/di/RepositoryModule.kt
+++ b/app/src/main/java/com/umc/product/di/RepositoryModule.kt
@@ -8,7 +8,7 @@ import com.umc.data.repository.member.MemberRepositoryImpl
 import com.umc.domain.repository.AuthRepository
 import com.umc.domain.repository.kakao.KakaoSearchRepository
 import com.umc.domain.repository.member.MemberRepository
-import com.umc.data.repository.ChallengerRepositoryImpl
+import com.umc.data.repository.challenger.ChallengerRepositoryImpl
 import com.umc.domain.repository.ChallengerRepository
 import dagger.Binds
 import dagger.Module

--- a/app/src/main/java/com/umc/product/di/UseCaseModule.kt
+++ b/app/src/main/java/com/umc/product/di/UseCaseModule.kt
@@ -3,10 +3,12 @@ package com.umc.product.di
 import com.umc.domain.repository.AuthRepository
 import com.umc.domain.repository.member.MemberRepository
 import com.umc.domain.repository.ChallengerRepository
+import com.umc.domain.repository.schedule.ScheduleRepository
 import com.umc.domain.usecase.challenger.GetChallengerDetailUseCase
 import com.umc.domain.usecase.PostLoginUseCase
 import com.umc.domain.usecase.member.GetMemberProfileUseCase
 import com.umc.domain.usecase.member.GetMyProfileUseCase
+import com.umc.domain.usecase.schedule.GetScheduleDetailUseCase
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -47,5 +49,11 @@ object UseCaseModule {
     @Provides
     fun providesGetChallengerDetailUseCase(repository: ChallengerRepository): GetChallengerDetailUseCase {
         return GetChallengerDetailUseCase(repository)
+    }
+
+    @Singleton
+    @Provides
+    fun providesGetScheduleDetailUseCase(repository: ScheduleRepository): GetScheduleDetailUseCase {
+        return GetScheduleDetailUseCase(repository)
     }
 }

--- a/app/src/main/java/com/umc/product/di/UseCaseModule.kt
+++ b/app/src/main/java/com/umc/product/di/UseCaseModule.kt
@@ -1,12 +1,10 @@
 package com.umc.product.di
 
-import com.umc.domain.repository.AppDataStoreRepository
 import com.umc.domain.repository.AuthRepository
 import com.umc.domain.repository.member.MemberRepository
 import com.umc.domain.repository.ChallengerRepository
-import com.umc.domain.usecase.GetChallengerDetailUseCase
+import com.umc.domain.usecase.challenger.GetChallengerDetailUseCase
 import com.umc.domain.usecase.PostLoginUseCase
-import com.umc.domain.usecase.appDataStore.UpdateUserInfoUseCase
 import com.umc.domain.usecase.member.GetMemberProfileUseCase
 import com.umc.domain.usecase.member.GetMyProfileUseCase
 import dagger.Module

--- a/data/src/main/java/com/umc/data/api/AttendanceApi.kt
+++ b/data/src/main/java/com/umc/data/api/AttendanceApi.kt
@@ -6,5 +6,5 @@ import retrofit2.http.GET
 
 interface AttendanceApi {
     @GET(Endpoints.Attendance.AVAILABLE)
-    suspend fun getAttendanceAvailable(): ApiResponse<AttendanceAvailableResponse>
+    suspend fun getAttendanceAvailable(): ApiResponse<List<AttendanceAvailableResponse>>
 }

--- a/data/src/main/java/com/umc/data/api/AttendanceApi.kt
+++ b/data/src/main/java/com/umc/data/api/AttendanceApi.kt
@@ -1,0 +1,10 @@
+package com.umc.data.api
+
+import com.umc.data.response.attendance.AttendanceAvailableResponse
+import com.umc.domain.model.base.ApiResponse
+import retrofit2.http.GET
+
+interface AttendanceApi {
+    @GET(Endpoints.Attendance.AVAILABLE)
+    suspend fun getAttendanceAvailable(): ApiResponse<AttendanceAvailableResponse>
+}

--- a/data/src/main/java/com/umc/data/api/Endpoints.kt
+++ b/data/src/main/java/com/umc/data/api/Endpoints.kt
@@ -28,6 +28,11 @@ object Endpoints {
         const val MEMBER_PROFILE = "$MEMBER/profile/{memberId}"
     }
 
+    object Schedule{
+        const val SCHEDULE = "api/v1/schedules"
+        const val DETAIL = "$SCHEDULE/{scheduleId}"
+    }
+
     object Kakao{
         const val SEARCH_LOCATION = "v2/local/search/keyword.json"
     }

--- a/data/src/main/java/com/umc/data/api/Endpoints.kt
+++ b/data/src/main/java/com/umc/data/api/Endpoints.kt
@@ -12,7 +12,7 @@ object Endpoints {
     }
 
     object Attendance {
-        const val ATTENDANCE = "api/v1/attendance"
+        const val ATTENDANCE = "api/v1/attendances"
         const val AVAILABLE = "$ATTENDANCE/available"
     }
 

--- a/data/src/main/java/com/umc/data/api/Endpoints.kt
+++ b/data/src/main/java/com/umc/data/api/Endpoints.kt
@@ -11,13 +11,16 @@ object Endpoints {
         const val EMAIL_VERIFICATION_COMPLETE = "$EMAIL_VERIFICATION/complete"
     }
 
+    object Attendance {
+        const val ATTENDANCE = "api/v1/attendance"
+        const val AVAILABLE = "$ATTENDANCE/available"
+    }
+
     object Challenger {
         const val CHALLENGER = "api/v1/challenger"
         const val DETAIL = "$CHALLENGER/{challengerId}"
         const val POINT = "$CHALLENGER/{challengerId}/points"
     }
-    // TODO 경로명 입력
-
 
     object Member{
         const val MEMBER = "api/v1/member"

--- a/data/src/main/java/com/umc/data/api/ScheduleApi.kt
+++ b/data/src/main/java/com/umc/data/api/ScheduleApi.kt
@@ -1,0 +1,11 @@
+package com.umc.data.api
+
+import com.umc.data.response.schedule.ScheduleDetailResponse
+import com.umc.domain.model.base.ApiResponse
+import retrofit2.http.GET
+import retrofit2.http.Path
+
+interface ScheduleApi {
+    @GET(Endpoints.Schedule.DETAIL)
+    suspend fun getScheduleDetail(@Path("scheduleId") scheduleId: Int): ApiResponse<ScheduleDetailResponse>
+}

--- a/data/src/main/java/com/umc/data/dataSource/remote/attendance/AttendanceRemoteDataSource.kt
+++ b/data/src/main/java/com/umc/data/dataSource/remote/attendance/AttendanceRemoteDataSource.kt
@@ -1,0 +1,8 @@
+package com.umc.data.dataSource.remote.attendance
+
+import com.umc.data.response.attendance.AttendanceAvailableResponse
+import com.umc.domain.model.base.ApiState
+
+interface AttendanceRemoteDataSource {
+    suspend fun getAttendanceAvailable(): ApiState<AttendanceAvailableResponse>
+}

--- a/data/src/main/java/com/umc/data/dataSource/remote/attendance/AttendanceRemoteDataSource.kt
+++ b/data/src/main/java/com/umc/data/dataSource/remote/attendance/AttendanceRemoteDataSource.kt
@@ -4,5 +4,5 @@ import com.umc.data.response.attendance.AttendanceAvailableResponse
 import com.umc.domain.model.base.ApiState
 
 interface AttendanceRemoteDataSource {
-    suspend fun getAttendanceAvailable(): ApiState<AttendanceAvailableResponse>
+    suspend fun getAttendanceAvailable(): ApiState<List<AttendanceAvailableResponse>>
 }

--- a/data/src/main/java/com/umc/data/dataSource/remote/attendance/AttendanceRemoteDataSourceImpl.kt
+++ b/data/src/main/java/com/umc/data/dataSource/remote/attendance/AttendanceRemoteDataSourceImpl.kt
@@ -10,7 +10,7 @@ class AttendanceRemoteDataSourceImpl @Inject constructor(
     private val attendanceApi: AttendanceApi
 ) : AttendanceRemoteDataSource {
 
-    override suspend fun getAttendanceAvailable(): ApiState<AttendanceAvailableResponse> {
+    override suspend fun getAttendanceAvailable(): ApiState<List<AttendanceAvailableResponse>> {
         return apiCall { attendanceApi.getAttendanceAvailable() }
     }
 }

--- a/data/src/main/java/com/umc/data/dataSource/remote/attendance/AttendanceRemoteDataSourceImpl.kt
+++ b/data/src/main/java/com/umc/data/dataSource/remote/attendance/AttendanceRemoteDataSourceImpl.kt
@@ -1,0 +1,16 @@
+package com.umc.data.dataSource.remote.attendance
+
+import com.umc.data.api.AttendanceApi
+import com.umc.data.dataSource.base.apiCall
+import com.umc.data.response.attendance.AttendanceAvailableResponse
+import com.umc.domain.model.base.ApiState
+import javax.inject.Inject
+
+class AttendanceRemoteDataSourceImpl @Inject constructor(
+    private val attendanceApi: AttendanceApi
+) : AttendanceRemoteDataSource {
+
+    override suspend fun getAttendanceAvailable(): ApiState<AttendanceAvailableResponse> {
+        return apiCall { attendanceApi.getAttendanceAvailable() }
+    }
+}

--- a/data/src/main/java/com/umc/data/dataSource/remote/challenger/ChallengerRemoteDataSource.kt
+++ b/data/src/main/java/com/umc/data/dataSource/remote/challenger/ChallengerRemoteDataSource.kt
@@ -1,4 +1,4 @@
-package com.umc.data.dataSource
+package com.umc.data.dataSource.remote.challenger
 
 import com.umc.data.response.challenger.ChallengerResponse
 import com.umc.domain.model.base.ApiState

--- a/data/src/main/java/com/umc/data/dataSource/remote/challenger/ChallengerRemoteDataSourceImpl.kt
+++ b/data/src/main/java/com/umc/data/dataSource/remote/challenger/ChallengerRemoteDataSourceImpl.kt
@@ -1,7 +1,6 @@
-package com.umc.data.dataSource.remote
+package com.umc.data.dataSource.remote.challenger
 
 import com.umc.data.api.ChallengerApi
-import com.umc.data.dataSource.ChallengerRemoteDataSource
 import com.umc.data.dataSource.base.apiCall
 import com.umc.data.response.challenger.ChallengerResponse
 import com.umc.domain.model.base.ApiState

--- a/data/src/main/java/com/umc/data/dataSource/remote/schedule/ScheduleRemoteDataSource.kt
+++ b/data/src/main/java/com/umc/data/dataSource/remote/schedule/ScheduleRemoteDataSource.kt
@@ -1,0 +1,8 @@
+package com.umc.data.dataSource.remote.schedule
+
+import com.umc.data.response.schedule.ScheduleDetailResponse
+import com.umc.domain.model.base.ApiState
+
+interface ScheduleRemoteDataSource {
+    suspend fun getScheduleDetail(scheduleId: Int): ApiState<ScheduleDetailResponse>
+}

--- a/data/src/main/java/com/umc/data/dataSource/remote/schedule/ScheduleRemoteDataSourceImpl.kt
+++ b/data/src/main/java/com/umc/data/dataSource/remote/schedule/ScheduleRemoteDataSourceImpl.kt
@@ -1,0 +1,16 @@
+package com.umc.data.dataSource.remote.schedule
+
+import com.umc.data.api.ScheduleApi
+import com.umc.data.dataSource.base.apiCall
+import com.umc.data.response.schedule.ScheduleDetailResponse
+import com.umc.domain.model.base.ApiState
+import javax.inject.Inject
+
+class ScheduleRemoteDataSourceImpl @Inject constructor(
+    private val scheduleApi: ScheduleApi
+) : ScheduleRemoteDataSource {
+
+    override suspend fun getScheduleDetail(scheduleId: Int): ApiState<ScheduleDetailResponse> {
+        return apiCall { scheduleApi.getScheduleDetail(scheduleId) }
+    }
+}

--- a/data/src/main/java/com/umc/data/repository/attendance/AttendanceRepositoryImpl.kt
+++ b/data/src/main/java/com/umc/data/repository/attendance/AttendanceRepositoryImpl.kt
@@ -1,0 +1,18 @@
+package com.umc.data.repository.attendance
+
+import com.umc.data.dataSource.remote.attendance.AttendanceRemoteDataSource
+import com.umc.data.response.attendance.AttendanceAvailableResponse.Companion.toModel
+import com.umc.domain.model.act.check.UserCheckAvailable
+import com.umc.domain.model.base.ApiState
+import com.umc.domain.model.base.map
+import com.umc.domain.repository.attendance.AttendanceRepository
+import javax.inject.Inject
+
+class AttendanceRepositoryImpl @Inject constructor(
+    private val attendanceRemoteDataSource: AttendanceRemoteDataSource
+) : AttendanceRepository {
+
+    override suspend fun getAttendanceAvailable(): ApiState<UserCheckAvailable> {
+        return attendanceRemoteDataSource.getAttendanceAvailable().map { it.toModel() }
+    }
+}

--- a/data/src/main/java/com/umc/data/repository/attendance/AttendanceRepositoryImpl.kt
+++ b/data/src/main/java/com/umc/data/repository/attendance/AttendanceRepositoryImpl.kt
@@ -12,7 +12,9 @@ class AttendanceRepositoryImpl @Inject constructor(
     private val attendanceRemoteDataSource: AttendanceRemoteDataSource
 ) : AttendanceRepository {
 
-    override suspend fun getAttendanceAvailable(): ApiState<UserCheckAvailable> {
-        return attendanceRemoteDataSource.getAttendanceAvailable().map { it.toModel() }
+    override suspend fun getAttendanceAvailable(): ApiState<List<UserCheckAvailable>> {
+        return attendanceRemoteDataSource.getAttendanceAvailable().map { responseList ->
+            responseList.map { it.toModel() }
+        }
     }
 }

--- a/data/src/main/java/com/umc/data/repository/challenger/ChallengerRepositoryImpl.kt
+++ b/data/src/main/java/com/umc/data/repository/challenger/ChallengerRepositoryImpl.kt
@@ -1,6 +1,6 @@
-package com.umc.data.repository
+package com.umc.data.repository.challenger
 
-import com.umc.data.dataSource.ChallengerRemoteDataSource
+import com.umc.data.dataSource.remote.challenger.ChallengerRemoteDataSource
 import com.umc.data.response.challenger.ChallengerResponse.Companion.toManageModel
 import com.umc.data.response.challenger.ChallengerResponse.Companion.toModel
 import com.umc.domain.model.act.challenger.ChallengerInfoDialogModel

--- a/data/src/main/java/com/umc/data/repository/schedule/ScheduleRepositoryImpl.kt
+++ b/data/src/main/java/com/umc/data/repository/schedule/ScheduleRepositoryImpl.kt
@@ -1,0 +1,20 @@
+package com.umc.data.repository.schedule
+
+import com.umc.data.dataSource.remote.schedule.ScheduleRemoteDataSource
+import com.umc.data.response.schedule.ScheduleDetailResponse.Companion.toModel
+import com.umc.domain.model.act.check.UserCheckAvailable
+import com.umc.domain.model.base.ApiState
+import com.umc.domain.model.base.map
+import com.umc.domain.repository.schedule.ScheduleRepository
+import javax.inject.Inject
+
+class ScheduleRepositoryImpl @Inject constructor(
+    private val scheduleRemoteDataSource: ScheduleRemoteDataSource
+) : ScheduleRepository {
+
+    override suspend fun getScheduleDetail(scheduleId: Int): ApiState<UserCheckAvailable> {
+        return scheduleRemoteDataSource.getScheduleDetail(scheduleId).map { response ->
+            response.toModel()
+        }
+    }
+}

--- a/data/src/main/java/com/umc/data/response/attendance/AttendanceAvailableResponse.kt
+++ b/data/src/main/java/com/umc/data/response/attendance/AttendanceAvailableResponse.kt
@@ -1,0 +1,34 @@
+package com.umc.data.response.attendance
+
+import com.google.gson.annotations.SerializedName
+import com.umc.domain.model.act.check.UserCheckAvailable
+import com.umc.domain.model.enums.CategoryType
+import com.umc.domain.model.enums.CheckAvailableStatus
+
+data class AttendanceAvailableResponse(
+    @SerializedName("scheduleId") val scheduleId: Int,
+    @SerializedName("scheduleName") val scheduleName: String,
+    @SerializedName("tags") val tags: List<CategoryType>?,
+    @SerializedName("startTime") val startTime: String,
+    @SerializedName("endTime") val endTime: String,
+    @SerializedName("sheetId") val sheetId: Int,
+    @SerializedName("recordId") val recordId: Int,
+    @SerializedName("status") val status: CheckAvailableStatus,
+    @SerializedName("statusDisplay") val statusDisplay: String?
+) {
+    companion object {
+        fun AttendanceAvailableResponse.toModel(): UserCheckAvailable {
+            return UserCheckAvailable(
+                id = scheduleId,
+                title = scheduleName,
+                startTime = startTime,
+                endTime = endTime,
+                status = status,
+                latitude = 0.0,
+                longitude = 0.0,
+                address = "",
+                isLocationCertified = null
+            )
+        }
+    }
+}

--- a/data/src/main/java/com/umc/data/response/attendance/AttendanceAvailableResponse.kt
+++ b/data/src/main/java/com/umc/data/response/attendance/AttendanceAvailableResponse.kt
@@ -21,6 +21,7 @@ data class AttendanceAvailableResponse(
             return UserCheckAvailable(
                 id = scheduleId,
                 title = scheduleName,
+                tags = tags,
                 startTime = startTime,
                 endTime = endTime,
                 status = status,

--- a/data/src/main/java/com/umc/data/response/schedule/ScheduleDetailResponse.kt
+++ b/data/src/main/java/com/umc/data/response/schedule/ScheduleDetailResponse.kt
@@ -1,0 +1,39 @@
+package com.umc.data.response.schedule
+
+import com.google.gson.annotations.SerializedName
+import com.umc.domain.model.act.check.UserCheckAvailable
+import com.umc.domain.model.enums.CategoryType
+import com.umc.domain.model.enums.CheckAvailableStatus
+
+data class ScheduleDetailResponse(
+    @SerializedName("scheduleId") val scheduleId: Int,
+    @SerializedName("name") val name: String,
+    @SerializedName("description") val description: String?,
+    @SerializedName("tags") val tags: List<CategoryType>?,
+    @SerializedName("startsAt") val startsAt: String,
+    @SerializedName("endsAt") val endsAt: String,
+    @SerializedName("isAllDay") val isAllDay: Boolean,
+    @SerializedName("locationName") val locationName: String?,
+    @SerializedName("latitude") val latitude: Double?,
+    @SerializedName("longitude") val longitude: Double?,
+    @SerializedName("status") val status: String?,
+    @SerializedName("dDay") val dDay: Int?,
+    @SerializedName("requiresAttendanceApproval") val requiresAttendanceApproval: Boolean?
+) {
+    companion object {
+        fun ScheduleDetailResponse.toModel(): UserCheckAvailable {
+            return UserCheckAvailable(
+                id = scheduleId,
+                title = name,
+                tags = tags,
+                startTime = startsAt,
+                endTime = endsAt,
+                status = CheckAvailableStatus.BEFORE,
+                latitude = latitude ?: 0.0,
+                longitude = longitude ?: 0.0,
+                address = locationName ?: "",
+                isLocationCertified = null
+            )
+        }
+    }
+}

--- a/domain/src/main/java/com/umc/domain/model/act/check/UserCheckAvailable.kt
+++ b/domain/src/main/java/com/umc/domain/model/act/check/UserCheckAvailable.kt
@@ -1,5 +1,6 @@
 package com.umc.domain.model.act.check
 
+import com.umc.domain.model.enums.CategoryType
 import com.umc.domain.model.enums.CheckAvailableStatus
 
 /**
@@ -8,6 +9,7 @@ import com.umc.domain.model.enums.CheckAvailableStatus
 data class UserCheckAvailable(
     val id: Int,
     val title: String,
+    val tags: List<CategoryType>?,
     val startTime: String,
     val endTime: String,
     val status: CheckAvailableStatus,

--- a/domain/src/main/java/com/umc/domain/model/act/check/UserCheckAvailable.kt
+++ b/domain/src/main/java/com/umc/domain/model/act/check/UserCheckAvailable.kt
@@ -10,7 +10,6 @@ data class UserCheckAvailable(
     val title: String,
     val startTime: String,
     val endTime: String,
-    val admin: String,
     val status: CheckAvailableStatus,
     val latitude: Double,
     val longitude: Double,

--- a/domain/src/main/java/com/umc/domain/repository/attendance/AttendanceRepository.kt
+++ b/domain/src/main/java/com/umc/domain/repository/attendance/AttendanceRepository.kt
@@ -4,5 +4,5 @@ import com.umc.domain.model.act.check.UserCheckAvailable
 import com.umc.domain.model.base.ApiState
 
 interface AttendanceRepository {
-    suspend fun getAttendanceAvailable(): ApiState<UserCheckAvailable>
+    suspend fun getAttendanceAvailable(): ApiState<List<UserCheckAvailable>>
 }

--- a/domain/src/main/java/com/umc/domain/repository/attendance/AttendanceRepository.kt
+++ b/domain/src/main/java/com/umc/domain/repository/attendance/AttendanceRepository.kt
@@ -1,0 +1,8 @@
+package com.umc.domain.repository.attendance
+
+import com.umc.domain.model.act.check.UserCheckAvailable
+import com.umc.domain.model.base.ApiState
+
+interface AttendanceRepository {
+    suspend fun getAttendanceAvailable(): ApiState<UserCheckAvailable>
+}

--- a/domain/src/main/java/com/umc/domain/repository/schedule/ScheduleRepository.kt
+++ b/domain/src/main/java/com/umc/domain/repository/schedule/ScheduleRepository.kt
@@ -1,0 +1,8 @@
+package com.umc.domain.repository.schedule
+
+import com.umc.domain.model.act.check.UserCheckAvailable
+import com.umc.domain.model.base.ApiState
+
+interface ScheduleRepository {
+    suspend fun getScheduleDetail(scheduleId: Int): ApiState<UserCheckAvailable>
+}

--- a/domain/src/main/java/com/umc/domain/usecase/attendance/GetAttendanceAvailableUseCase.kt
+++ b/domain/src/main/java/com/umc/domain/usecase/attendance/GetAttendanceAvailableUseCase.kt
@@ -1,0 +1,14 @@
+package com.umc.domain.usecase.attendance
+
+import com.umc.domain.model.act.check.UserCheckAvailable
+import com.umc.domain.model.base.ApiState
+import com.umc.domain.repository.attendance.AttendanceRepository
+import javax.inject.Inject
+
+class GetAttendanceAvailableUseCase @Inject constructor(
+    private val attendanceRepository: AttendanceRepository
+) {
+    suspend operator fun invoke(): ApiState<UserCheckAvailable> {
+        return attendanceRepository.getAttendanceAvailable()
+    }
+}

--- a/domain/src/main/java/com/umc/domain/usecase/attendance/GetAttendanceAvailableUseCase.kt
+++ b/domain/src/main/java/com/umc/domain/usecase/attendance/GetAttendanceAvailableUseCase.kt
@@ -8,7 +8,7 @@ import javax.inject.Inject
 class GetAttendanceAvailableUseCase @Inject constructor(
     private val attendanceRepository: AttendanceRepository
 ) {
-    suspend operator fun invoke(): ApiState<UserCheckAvailable> {
+    suspend operator fun invoke(): ApiState<List<UserCheckAvailable>> {
         return attendanceRepository.getAttendanceAvailable()
     }
 }

--- a/domain/src/main/java/com/umc/domain/usecase/challenger/GetAdminChallengerDetailUseCase.kt
+++ b/domain/src/main/java/com/umc/domain/usecase/challenger/GetAdminChallengerDetailUseCase.kt
@@ -1,4 +1,4 @@
-package com.umc.domain.usecase
+package com.umc.domain.usecase.challenger
 
 import com.umc.domain.model.act.challenger.ChallengerManageDialogModel
 import com.umc.domain.model.base.ApiState

--- a/domain/src/main/java/com/umc/domain/usecase/challenger/GetChallengerDetailUseCase.kt
+++ b/domain/src/main/java/com/umc/domain/usecase/challenger/GetChallengerDetailUseCase.kt
@@ -1,4 +1,4 @@
-package com.umc.domain.usecase
+package com.umc.domain.usecase.challenger
 
 import com.umc.domain.model.act.challenger.ChallengerInfoDialogModel
 import com.umc.domain.model.base.ApiState

--- a/domain/src/main/java/com/umc/domain/usecase/challenger/GrantChallengerPointUseCase.kt
+++ b/domain/src/main/java/com/umc/domain/usecase/challenger/GrantChallengerPointUseCase.kt
@@ -1,4 +1,4 @@
-package com.umc.domain.usecase
+package com.umc.domain.usecase.challenger
 
 import com.umc.domain.model.act.challenger.ChallengerManageDialogModel
 import com.umc.domain.model.base.ApiState

--- a/domain/src/main/java/com/umc/domain/usecase/schedule/GetScheduleDetailUseCase.kt
+++ b/domain/src/main/java/com/umc/domain/usecase/schedule/GetScheduleDetailUseCase.kt
@@ -1,0 +1,14 @@
+package com.umc.domain.usecase.schedule
+
+import com.umc.domain.model.act.check.UserCheckAvailable
+import com.umc.domain.model.base.ApiState
+import com.umc.domain.repository.schedule.ScheduleRepository
+import javax.inject.Inject
+
+class GetScheduleDetailUseCase @Inject constructor(
+    private val scheduleRepository: ScheduleRepository
+) {
+    suspend operator fun invoke(scheduleId: Int): ApiState<UserCheckAvailable> {
+        return scheduleRepository.getScheduleDetail(scheduleId)
+    }
+}

--- a/presentation/src/main/java/com/umc/presentation/ui/act/challenge/AdminChallengerViewModel.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/act/challenge/AdminChallengerViewModel.kt
@@ -7,8 +7,8 @@ import com.umc.domain.model.base.ApiState
 import com.umc.domain.model.enums.PointType
 import com.umc.domain.model.enums.UserPart
 import com.umc.domain.model.request.challenger.ChallengerPointRequest
-import com.umc.domain.usecase.GetAdminChallengerDetailUseCase
-import com.umc.domain.usecase.GrantChallengerPointUseCase
+import com.umc.domain.usecase.challenger.GetAdminChallengerDetailUseCase
+import com.umc.domain.usecase.challenger.GrantChallengerPointUseCase
 import com.umc.presentation.base.BaseViewModel
 import com.umc.presentation.base.UiEvent
 import com.umc.presentation.base.UiState

--- a/presentation/src/main/java/com/umc/presentation/ui/act/challenge/UserChallengerViewModel.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/act/challenge/UserChallengerViewModel.kt
@@ -6,7 +6,7 @@ import com.umc.domain.model.act.challenger.UserChallenger
 import com.umc.domain.model.base.ApiState
 import com.umc.domain.model.enums.UserChallengerRole
 import com.umc.domain.model.enums.UserPart
-import com.umc.domain.usecase.GetChallengerDetailUseCase
+import com.umc.domain.usecase.challenger.GetChallengerDetailUseCase
 import com.umc.presentation.base.BaseViewModel
 import com.umc.presentation.base.UiEvent
 import com.umc.presentation.base.UiState

--- a/presentation/src/main/java/com/umc/presentation/ui/act/check/UserCheckBindingAdapters.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/act/check/UserCheckBindingAdapters.kt
@@ -8,6 +8,7 @@ import androidx.core.content.ContextCompat
 import androidx.databinding.BindingAdapter
 import com.google.android.material.card.MaterialCardView
 import com.google.android.material.shape.CornerFamily
+import com.umc.domain.model.enums.CategoryType
 import com.umc.domain.model.enums.CheckAvailableStatus
 import com.umc.domain.model.enums.CheckHistoryStatus
 import com.umc.presentation.R
@@ -34,6 +35,36 @@ object UserCheckBindingAdapters {
 
         view.setCardBackgroundColor(ContextCompat.getColor(view.context, bgColorRes))
         view.setTextColor(ContextCompat.getColor(view.context, textColorRes))
+    }
+
+    /**
+     * 태그 리스트의 첫 번째 항목에 따라 세션 아이콘 설정
+     */
+    @JvmStatic
+    @BindingAdapter("sessionIconByTag")
+    fun setSessionIconByTag(view: ImageView, tags: List<CategoryType>?) {
+        if (tags.isNullOrEmpty()) {
+            view.setImageResource(R.drawable.ic_people_color)
+            return
+        }
+
+        // 첫 번째 태그에 따라 아이콘 분기 처리
+        val iconRes = when (tags.first()) {
+            CategoryType.NETWORKING -> R.drawable.ic_networking_on
+            CategoryType.PROJECT -> R.drawable.ic_project_on
+            CategoryType.DUES -> R.drawable.ic_fees_on
+            CategoryType.MEETING -> R.drawable.ic_meeting_on
+            CategoryType.ORIENTATION -> R.drawable.ic_orientation_on
+            CategoryType.PRESENTATION -> R.drawable.ic_presentation_on
+            CategoryType.RETROSPECTIVE -> R.drawable.ic_retrospective_on
+            CategoryType.GENERAL -> R.drawable.ic_general_on
+            CategoryType.LEADERSHIP -> R.drawable.ic_leadership_on
+            CategoryType.STUDY -> R.drawable.ic_study_on
+            CategoryType.HACKATHON -> R.drawable.ic_workshop_on
+            CategoryType.WORKSHOP -> R.drawable.ic_workshop_on
+            else -> R.drawable.ic_people_color
+        }
+        view.setImageResource(iconRes)
     }
 
     /**

--- a/presentation/src/main/java/com/umc/presentation/ui/act/check/UserCheckFragment.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/act/check/UserCheckFragment.kt
@@ -3,6 +3,7 @@ package com.umc.presentation.ui.act.check
 import android.Manifest
 import android.content.pm.PackageManager
 import android.os.Looper
+import android.widget.Toast
 import androidx.annotation.RequiresPermission
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.viewModels
@@ -57,19 +58,18 @@ class UserCheckFragment : BaseFragment<FragmentUserCheckBinding, UserCheckUiStat
 
     override fun initView() {
         locationSource = FusedLocationSource(this, LOCATION_PERMISSION_REQUEST_CODE)
-
         fusedLocationClient = LocationServices.getFusedLocationProviderClient(requireActivity())
-        setupLocationCallback()
 
+        setupLocationCallback()
         checkLocationPermissions()
         setupMainRecyclerView()
     }
 
-    // 위치 업데이트 콜백 설정
     private fun setupLocationCallback() {
         locationCallback = object : LocationCallback() {
             override fun onLocationResult(locationResult: LocationResult) {
-                for (location in locationResult.locations) {
+                // 실시간 위치 정보를 뷰모델에 전달하여 거리 계산 수행
+                locationResult.lastLocation?.let { location ->
                     viewModel.updateLocation(location.latitude, location.longitude)
                 }
             }
@@ -104,25 +104,29 @@ class UserCheckFragment : BaseFragment<FragmentUserCheckBinding, UserCheckUiStat
     @RequiresPermission(anyOf = [Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION])
     override fun initStates() {
         repeatOnStarted(viewLifecycleOwner) {
+            // 1. UI State 구독: 리스트 및 카운트 업데이트
             launch {
                 viewModel.uiState.collect { state ->
+                    // 가용한 세션 업데이트
                     availableAdapter.submitList(state.availableSessions)
                     availableHeaderAdapter.updateCount(state.availableCount)
 
-                    if (state.availableSessions.isEmpty()) {
-                        availableEmptyAdapter.submitList(listOf(EmptyStateUIModel(R.drawable.ic_people, getString(R.string.attendance_empty_available))))
-                    } else {
-                        availableEmptyAdapter.submitList(emptyList())
-                    }
+                    // 빈 화면 처리 (EmptyStateAdapter)
+                    val availableEmptyList = if (state.availableSessions.isEmpty()) {
+                        listOf(EmptyStateUIModel(R.drawable.ic_people, getString(R.string.attendance_empty_available)))
+                    } else emptyList()
+                    availableEmptyAdapter.submitList(availableEmptyList)
 
+                    // 출석 히스토리 업데이트
                     historyAdapter.submitList(state.attendanceHistories)
-                    if (state.attendanceHistories.isEmpty()) {
-                        historyEmptyAdapter.submitList(listOf(EmptyStateUIModel(R.drawable.ic_document, getString(R.string.attendance_empty_history))))
-                    } else {
-                        historyEmptyAdapter.submitList(emptyList())
-                    }
+                    val historyEmptyList = if (state.attendanceHistories.isEmpty()) {
+                        listOf(EmptyStateUIModel(R.drawable.ic_document, getString(R.string.attendance_empty_history)))
+                    } else emptyList()
+                    historyEmptyAdapter.submitList(historyEmptyList)
                 }
             }
+
+            // 2. UI Event 구독: 일회성 액션(토스트, 다이얼로그) 처리
             launch {
                 viewModel.uiEvent.collect { event -> handleEvent(event) }
             }
@@ -159,8 +163,12 @@ class UserCheckFragment : BaseFragment<FragmentUserCheckBinding, UserCheckUiStat
     override fun handleEvent(event: UserCheckEvent) {
         when (event) {
             is UserCheckEvent.ShowReasonDialog -> showAttendanceReasonDialog(event.sessionId)
-            is UserCheckEvent.ShowToast -> { /* 토스트 출력 */ }
-            else -> {}
+            is UserCheckEvent.ShowToast -> {
+                Toast.makeText(requireContext(), event.message, Toast.LENGTH_SHORT).show()
+            }
+            is UserCheckEvent.NavigateToFailureReason -> {
+
+            }
         }
     }
 

--- a/presentation/src/main/java/com/umc/presentation/ui/act/check/UserCheckViewModel.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/act/check/UserCheckViewModel.kt
@@ -1,12 +1,13 @@
 package com.umc.presentation.ui.act.check
 
 import androidx.lifecycle.viewModelScope
-import com.umc.domain.model.act.check.UserCheckHistory
 import com.umc.domain.model.act.check.UserCheckAvailable
+import com.umc.domain.model.act.check.UserCheckHistory
 import com.umc.domain.model.base.ApiState
 import com.umc.domain.model.enums.CheckAvailableStatus
 import com.umc.domain.model.enums.CheckHistoryStatus
 import com.umc.domain.usecase.attendance.GetAttendanceAvailableUseCase
+import com.umc.domain.usecase.schedule.GetScheduleDetailUseCase
 import com.umc.presentation.base.BaseViewModel
 import com.umc.presentation.base.UiEvent
 import com.umc.presentation.base.UiState
@@ -16,47 +17,85 @@ import javax.inject.Inject
 
 @HiltViewModel
 class UserCheckViewModel @Inject constructor(
-    private val getAttendanceAvailableUseCase: GetAttendanceAvailableUseCase //
+    private val getAttendanceAvailableUseCase: GetAttendanceAvailableUseCase,
+    private val getScheduleDetailUseCase: GetScheduleDetailUseCase
 ) : BaseViewModel<UserCheckUiState, UserCheckEvent>(UserCheckUiState()) {
 
-    init {
-        fetchAvailableAttendance()
-    }
+    init { fetchAttendanceData() }
 
-    fun submitAttendanceReason(sessionId: Int, reason: String) {
-        // TODO: API 전송 로직 구현
-        emitEvent(UserCheckEvent.ShowToast("사유가 성공적으로 제출되었습니다."))
-    }
-
-    private fun fetchAvailableAttendance() {
+    private fun fetchAttendanceData() {
         viewModelScope.launch {
             when (val result = getAttendanceAvailableUseCase()) {
                 is ApiState.Success -> {
-                    val uiModels = result.data.map { session ->
-                        CheckAvailableUIModel(
-                            session = session,
-                            address = session.address
-                        )
-                    }
+                    val list = result.data.map { CheckAvailableUIModel(session = it) }
+                    updateState { copy(availableSessions = list, availableCount = list.size) }
 
+                    // 목록 로드 즉시 각 아이템의 상세(위치 정보) 요청
+                    list.forEach { fetchSessionDetail(it.session.id) }
+                }
+                is ApiState.Fail -> emitEvent(UserCheckEvent.ShowToast(result.failState.message))
+            }
+        }
+        loadHistoryDummyData()
+    }
+
+    private fun fetchSessionDetail(sessionId: Int) {
+        viewModelScope.launch {
+            when (val result = getScheduleDetailUseCase(sessionId)) {
+                is ApiState.Success -> {
+                    val detail = result.data
                     updateState {
-                        copy(
-                            availableSessions = uiModels,
-                            availableCount = uiModels.size
-                        )
+                        val updatedList = availableSessions.map { uiModel ->
+                            if (uiModel.session.id == sessionId) {
+                                // ⭐️ UIModel의 address와 session 내부 위경도를 모두 업데이트
+                                uiModel.copy(
+                                    address = detail.address,
+                                    session = uiModel.session.copy(
+                                        latitude = detail.latitude,
+                                        longitude = detail.longitude,
+                                        address = detail.address
+                                    )
+                                )
+                            } else uiModel
+                        }
+                        copy(availableSessions = updatedList)
                     }
                 }
-                is ApiState.Fail -> {
-                    emitEvent(UserCheckEvent.ShowToast(result.failState.message))
-                }
+                is ApiState.Fail -> { /* 실패 처리 */ }
             }
         }
     }
+    fun submitAttendanceReason(sessionId: Int, reason: String) {
+        // TODO: 출석 사유 제출 API 연동
+        emitEvent(UserCheckEvent.ShowToast("사유가 성공적으로 제출되었습니다."))
+    }
 
+    private fun loadHistoryDummyData() {
+        val rawHistoryList = listOf(
+            UserCheckHistory(1, "3주차", "정기 세션", "14:00", "18:00", CheckHistoryStatus.SUCCESS),
+            UserCheckHistory(2, "2주차", "정기 세션", "14:00", "18:00", CheckHistoryStatus.LATE),
+            UserCheckHistory(3, "1주차", "정기 세션", "14:00", "18:00", CheckHistoryStatus.ABSENT)
+        )
+
+        val historyUIList = rawHistoryList.mapIndexed { index, history ->
+            CheckHistoryUIModel(
+                history = history,
+                isFirst = index == 0,
+                isLast = index == rawHistoryList.size - 1
+            )
+        }
+
+        updateState { copy(attendanceHistories = historyUIList) }
+    }
+
+    /**
+     * 기존 위치 업데이트 및 거리 계산 로직 유지
+     */
     fun updateLocation(userLat: Double, userLng: Double) {
         updateState {
             val updatedList = availableSessions.map { uiModel ->
-                if (uiModel.session.status == CheckAvailableStatus.BEFORE) {
+                // 상세 정보를 받아와 위도/경도가 0.0이 아닐 때만 거리 계산 수행
+                if (uiModel.session.status == CheckAvailableStatus.BEFORE && uiModel.session.latitude != 0.0) {
                     val results = FloatArray(1)
                     android.location.Location.distanceBetween(
                         userLat, userLng,
@@ -73,7 +112,7 @@ class UserCheckViewModel @Inject constructor(
     }
 
     /**
-     * 특정 아이템을 클릭했을 때 확장 상태를 토글
+     * 특정 아이템을 클릭했을 때 확장 상태를 토글 (기존 로직 유지)
      */
     fun toggleSessionExpansion(sessionId: Int) {
         updateState {
@@ -95,6 +134,7 @@ data class UserCheckUiState(
     val availableCount: Int = 0,
     val geofenceRadius: Float = 50f
 ) : UiState
+
 sealed class UserCheckEvent : UiEvent {
     data class ShowToast(val message: String) : UserCheckEvent()
     data class ShowReasonDialog(val sessionId: Int) : UserCheckEvent()

--- a/presentation/src/main/java/com/umc/presentation/ui/act/check/UserCheckViewModel.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/act/check/UserCheckViewModel.kt
@@ -25,10 +25,10 @@ class UserCheckViewModel @Inject constructor() :
 
     private fun loadInitialData() {
         val availableList = listOf(
-            UserCheckAvailable(1, "스터디", "14:00", "18:00", "스터디장", CheckAvailableStatus.BEFORE, 37.504562, 126.956926, "서울특별시 동작구 흑석로 84"),
-            UserCheckAvailable(2, "스터디", "14:00", "18:00", "스터디장", CheckAvailableStatus.BEFORE, 37.582568, 127.001488, "서울특별시 종로구 명륜4가 88-2번지 주소를 길게 써보자ㅏㅏㅏㅏㅏㅏㅏ"),
-            UserCheckAvailable(3, "정기 세션 3주차", "14:00", "18:00", "운영진", CheckAvailableStatus.COMPLETED, 37.5665, 126.9780,"서울특별시 중구 소공동 세종대로18길 2", true),
-            UserCheckAvailable(4, "UMCON", "14:00", "18:00", "스터디장", CheckAvailableStatus.PENDING, 37.5665, 126.9780, "서울특별시 중구 소공동 세종대로18길 2", false)
+            UserCheckAvailable(1, "스터디", "14:00", "18:00", CheckAvailableStatus.BEFORE, 37.504562, 126.956926, "서울특별시 동작구 흑석로 84"),
+            UserCheckAvailable(2, "스터디", "14:00", "18:00", CheckAvailableStatus.BEFORE, 37.582568, 127.001488, "서울특별시 종로구 명륜4가 88-2번지 주소를 길게 써보자ㅏㅏㅏㅏㅏㅏㅏ"),
+            UserCheckAvailable(3, "정기 세션 3주차", "14:00", "18:00", CheckAvailableStatus.COMPLETED, 37.5665, 126.9780,"서울특별시 중구 소공동 세종대로18길 2", true),
+            UserCheckAvailable(4, "UMCON", "14:00", "18:00", CheckAvailableStatus.PENDING, 37.5665, 126.9780, "서울특별시 중구 소공동 세종대로18길 2", false)
         ).map {
             CheckAvailableUIModel(
                 session = it,
@@ -87,7 +87,7 @@ class UserCheckViewModel @Inject constructor() :
                 if (uiModel.session.id == sessionId) {
                     uiModel.copy(isExpanded = !uiModel.isExpanded)
                 } else {
-                    uiModel
+                    uiModel.copy(isExpanded = false)
                 }
             }
             copy(availableSessions = newList)

--- a/presentation/src/main/java/com/umc/presentation/ui/act/check/UserCheckViewModel.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/act/check/UserCheckViewModel.kt
@@ -1,21 +1,26 @@
 package com.umc.presentation.ui.act.check
 
+import androidx.lifecycle.viewModelScope
 import com.umc.domain.model.act.check.UserCheckHistory
 import com.umc.domain.model.act.check.UserCheckAvailable
+import com.umc.domain.model.base.ApiState
 import com.umc.domain.model.enums.CheckAvailableStatus
 import com.umc.domain.model.enums.CheckHistoryStatus
+import com.umc.domain.usecase.attendance.GetAttendanceAvailableUseCase
 import com.umc.presentation.base.BaseViewModel
 import com.umc.presentation.base.UiEvent
 import com.umc.presentation.base.UiState
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-class UserCheckViewModel @Inject constructor() :
-    BaseViewModel<UserCheckUiState, UserCheckEvent>(UserCheckUiState()) {
+class UserCheckViewModel @Inject constructor(
+    private val getAttendanceAvailableUseCase: GetAttendanceAvailableUseCase //
+) : BaseViewModel<UserCheckUiState, UserCheckEvent>(UserCheckUiState()) {
 
     init {
-        loadInitialData()
+        fetchAvailableAttendance()
     }
 
     fun submitAttendanceReason(sessionId: Int, reason: String) {
@@ -23,39 +28,28 @@ class UserCheckViewModel @Inject constructor() :
         emitEvent(UserCheckEvent.ShowToast("사유가 성공적으로 제출되었습니다."))
     }
 
-    private fun loadInitialData() {
-        val availableList = listOf(
-            UserCheckAvailable(1, "스터디", "14:00", "18:00", CheckAvailableStatus.BEFORE, 37.504562, 126.956926, "서울특별시 동작구 흑석로 84"),
-            UserCheckAvailable(2, "스터디", "14:00", "18:00", CheckAvailableStatus.BEFORE, 37.582568, 127.001488, "서울특별시 종로구 명륜4가 88-2번지 주소를 길게 써보자ㅏㅏㅏㅏㅏㅏㅏ"),
-            UserCheckAvailable(3, "정기 세션 3주차", "14:00", "18:00", CheckAvailableStatus.COMPLETED, 37.5665, 126.9780,"서울특별시 중구 소공동 세종대로18길 2", true),
-            UserCheckAvailable(4, "UMCON", "14:00", "18:00", CheckAvailableStatus.PENDING, 37.5665, 126.9780, "서울특별시 중구 소공동 세종대로18길 2", false)
-        ).map {
-            CheckAvailableUIModel(
-                session = it,
-                address = it.address
-            )
-        }
+    private fun fetchAvailableAttendance() {
+        viewModelScope.launch {
+            when (val result = getAttendanceAvailableUseCase()) {
+                is ApiState.Success -> {
+                    val uiModels = result.data.map { session ->
+                        CheckAvailableUIModel(
+                            session = session,
+                            address = session.address
+                        )
+                    }
 
-        val rawHistoryList = listOf(
-            UserCheckHistory(1, "3주차", "정기 세션", "14:00", "18:00", CheckHistoryStatus.SUCCESS),
-            UserCheckHistory(2, "2주차", "정기 세션", "14:00", "18:00", CheckHistoryStatus.LATE),
-            UserCheckHistory(3, "1주차", "정기 세션", "14:00", "18:00", CheckHistoryStatus.ABSENT)
-        )
-
-        val historyUIList = rawHistoryList.mapIndexed { index, history ->
-            CheckHistoryUIModel(
-                history = history,
-                isFirst = index == 0,
-                isLast = index == rawHistoryList.size - 1
-            )
-        }
-
-        updateState {
-            copy(
-                availableSessions = availableList,
-                attendanceHistories = historyUIList,
-                availableCount = availableList.size
-            )
+                    updateState {
+                        copy(
+                            availableSessions = uiModels,
+                            availableCount = uiModels.size
+                        )
+                    }
+                }
+                is ApiState.Fail -> {
+                    emitEvent(UserCheckEvent.ShowToast(result.failState.message))
+                }
+            }
         }
     }
 

--- a/presentation/src/main/java/com/umc/presentation/util/UFormat.kt
+++ b/presentation/src/main/java/com/umc/presentation/util/UFormat.kt
@@ -1,15 +1,31 @@
 package com.umc.presentation.util
 
 import java.time.LocalDate
+import java.time.LocalTime
 import java.time.format.DateTimeFormatter
 import java.util.Locale
 
 object UFormat {
     /**
      * 시작 시간과 종료 시간을 받아 "HH:mm - HH:mm" 형태의 문자열로 반환합니다.
+     * 입력 예: "10:00:00", "22:00:00" -> 출력 예: "10:00 - 22:00"
      */
     fun formatDuration(startTime: String, endTime: String): String {
-        return "$startTime - $endTime"
+        return try {
+            // "HH:mm:ss" 형태로 오는 서버 데이터를 위해 파서 정의
+            val inputFormatter = DateTimeFormatter.ofPattern("HH:mm:ss")
+            val outputFormatter = DateTimeFormatter.ofPattern("HH:mm")
+
+            val start = LocalTime.parse(startTime, inputFormatter).format(outputFormatter)
+            val end = LocalTime.parse(endTime, inputFormatter).format(outputFormatter)
+
+            "$start - $end"
+        } catch (e: Exception) {
+            // 파싱 실패 시 예외 처리 (콜론 개수로 문자열 직접 자르기)
+            val start = if (startTime.count { it == ':' } >= 2) startTime.substringBeforeLast(":") else startTime
+            val end = if (endTime.count { it == ':' } >= 2) endTime.substringBeforeLast(":") else endTime
+            "$start - $end"
+        }
     }
 
     /**

--- a/presentation/src/main/res/layout/item_act_check_available.xml
+++ b/presentation/src/main/res/layout/item_act_check_available.xml
@@ -32,7 +32,7 @@
                 android:id="@+id/cv_session_icon_container"
                 android:layout_width="48dp"
                 android:layout_height="48dp"
-                app:cardBackgroundColor="@color/primary100"
+                app:cardBackgroundColor="@android:color/transparent"
                 app:cardCornerRadius="12dp"
                 app:cardElevation="0dp"
                 app:strokeWidth="0dp"
@@ -41,10 +41,10 @@
 
                 <ImageView
                     android:id="@+id/iv_session_icon"
-                    android:layout_width="24dp"
-                    android:layout_height="24dp"
-                    android:layout_gravity="center"
-                    android:src="@drawable/ic_people_color" />
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    app:sessionIconByTag="@{uiModel.session.tags}"
+                    tools:src="@drawable/ic_networking_on" />
             </com.google.android.material.card.MaterialCardView>
 
             <TextView

--- a/presentation/src/main/res/layout/item_act_check_available.xml
+++ b/presentation/src/main/res/layout/item_act_check_available.xml
@@ -259,10 +259,9 @@
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_marginTop="8dp"
-                            android:text="@{@string/attendance_status_pending_description(uiModel.session.admin)}"
                             android:textAppearance="@style/Footnote"
                             android:textColor="@color/warning700"
-                            tools:text="스터디장님이 출석 정보를 확인하고 있습니다."/>
+                            android:text="출석 정보를 확인하고 있습니다."/>
                     </LinearLayout>
                 </com.google.android.material.card.MaterialCardView>
 


### PR DESCRIPTION
## #️⃣ 이슈 번호

> 관련된 이슈 번호를 적어주세요.\
> Close #65

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 요약해주세요.

출석 가능한 세션에 필요한 출석 가능한 세션 목록 조회, 일정 상세 조회 API를 연동하였고 아이템 단일 확장 로직을 구현하였습니다.

## 📸 스크린샷 (선택 사항)
| 출석 가능한 세션 |
| :---: |
| <img width="250" alt="image" src="https://github.com/user-attachments/assets/80f453da-0191-4ab8-8a1f-817a13427b1f" /> |

## 🚩 리뷰 요구사항
> 리뷰어가 중점적으로 봐주었으면 하는 부분이 있다면 작성해주세요.

스웨거 상에는 행사 및 스케줄이 묶여있지만 우선 엔드포인트 기준으로 Attendance(출석)랑 Schedule(일정)으로 나누었습니다.

## 🏁 체크리스트
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 로그나 주석을 제거했나요?
- [x] 머지 대상 브랜치(Base branch)가 올바른가요?
