### PR TITLE
[Feat/#101] - 리소스 접근 권한 API, 게시글/댓글 신고 API 연결 (오류 수정 추가)

### DIFF
--- a/app/src/main/java/com/umc/product/di/ApiModule.kt
+++ b/app/src/main/java/com/umc/product/di/ApiModule.kt
@@ -2,6 +2,7 @@ package com.umc.product.di
 
 import com.umc.data.api.AttendanceApi
 import com.umc.data.api.AuthApi
+import com.umc.data.api.AuthorizeApi
 import com.umc.data.api.MemberApi
 import com.umc.data.api.ChallengerApi
 import com.umc.data.api.CommunityApi
@@ -75,5 +76,11 @@ object ApiModule {
     @Provides
     fun provideTermsApi(@AuthRetrofit retrofit: Retrofit): TermsApi {
         return retrofit.create(TermsApi::class.java)
+    }
+
+    @Singleton
+    @Provides
+    fun provideAuthorizeApi(@AuthRetrofit retrofit: Retrofit): AuthorizeApi {
+        return retrofit.create(AuthorizeApi::class.java)
     }
 }

--- a/app/src/main/java/com/umc/product/di/AuthenticationInterceptor.kt
+++ b/app/src/main/java/com/umc/product/di/AuthenticationInterceptor.kt
@@ -25,8 +25,8 @@ class AuthenticationInterceptor @Inject constructor(
             }
 
             val accessToken = runBlocking { appDataStoreRepository.getAccessToken() }
-            val testToken = "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNzcxMzk0MDE5LCJleHAiO" +
-                    "jE3NzEzOTc2MTl9.S3eWPJmRcGDfjRoYmY_3pV4qPzlRynYZlXFvv4LaU4XoGM7tzyVQOEF3MIQBjxaTGhXVs0lprGAr8SAcJw6fnw"
+            val testToken = "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNzcxMzk4NDgwLCJleHAiOjE3" +
+                    "NzE0MDkyODB9.oAdVb1rRM7HFjzOmujDQYIK1HOHRZs3HjM5yZ-kM_ctMx4VSthmEzd2v8WaIMu96vJTueXxQ8P7cTAHv0D5zmg"
 
             val request =
                 chain.request().newBuilder()

--- a/app/src/main/java/com/umc/product/di/AuthenticationInterceptor.kt
+++ b/app/src/main/java/com/umc/product/di/AuthenticationInterceptor.kt
@@ -25,8 +25,8 @@ class AuthenticationInterceptor @Inject constructor(
             }
 
             val accessToken = runBlocking { appDataStoreRepository.getAccessToken() }
-            val testToken = "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNzcxMzIxNDY4LCJleHAiOjE3NzEzMjU" +
-                    "wNjh9.RgmR2ORK0_NSV8mTFhRtNtzcCA0gF0LoXRcaIKpKyDVaoBjOdFBri3BuVE5dNszy7AcBa1-MFaYotcXoe1P5Nw"
+            val testToken = "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNzcxMzI5Mzc2LCJleHAiOjE3NzEzMzI5NzZ9.v0ZHKROMScMPp" +
+                    "6LC-KTV7gnBoghndYj-99nYy4h0-VLr7EZJuwH1sr_sHWq8EHB9AJ0GXjuLh32jhEmdQQ6RQg"
 
             val request =
                 chain.request().newBuilder()

--- a/app/src/main/java/com/umc/product/di/AuthenticationInterceptor.kt
+++ b/app/src/main/java/com/umc/product/di/AuthenticationInterceptor.kt
@@ -30,7 +30,7 @@ class AuthenticationInterceptor @Inject constructor(
 
             val request =
                 chain.request().newBuilder()
-                    .addHeader("Authorization", "Bearer ${testToken}").build()
+                    .addHeader("Authorization", "Bearer ${accessToken}").build()
 
             Log.d(
                 "RETROFIT",

--- a/app/src/main/java/com/umc/product/di/AuthenticationInterceptor.kt
+++ b/app/src/main/java/com/umc/product/di/AuthenticationInterceptor.kt
@@ -25,8 +25,8 @@ class AuthenticationInterceptor @Inject constructor(
             }
 
             val accessToken = runBlocking { appDataStoreRepository.getAccessToken() }
-            val testToken = "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNzcxMzE4MzYzLCJleHAiOjE3NzE" +
-                    "zMjE5NjN9.8YQWlPHjs_8k-BpDuoMjgizu5EelaSEx3wJQ3aJRmfW3Ck8idYRVE0vl6EHBh3b010IoByxHd21oxw2UBnpbeA"
+            val testToken = "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNzcxMzIxNDY4LCJleHAiOjE3NzEzMjU" +
+                    "wNjh9.RgmR2ORK0_NSV8mTFhRtNtzcCA0gF0LoXRcaIKpKyDVaoBjOdFBri3BuVE5dNszy7AcBa1-MFaYotcXoe1P5Nw"
 
             val request =
                 chain.request().newBuilder()

--- a/app/src/main/java/com/umc/product/di/AuthenticationInterceptor.kt
+++ b/app/src/main/java/com/umc/product/di/AuthenticationInterceptor.kt
@@ -25,8 +25,8 @@ class AuthenticationInterceptor @Inject constructor(
             }
 
             val accessToken = runBlocking { appDataStoreRepository.getAccessToken() }
-            val testToken = "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNzcxMzI5Mzc2LCJleHAiOjE3NzEzMzI5NzZ9.v0ZHKROMScMPp" +
-                    "6LC-KTV7gnBoghndYj-99nYy4h0-VLr7EZJuwH1sr_sHWq8EHB9AJ0GXjuLh32jhEmdQQ6RQg"
+            val testToken = "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNzcxMzMzMTA" +
+                    "xLCJleHAiOjE3NzEzMzY3MDF9.aECNrnOmnYKSjqusLf5SsvwSDcmQQpoMduJhgQvz_LPAaEYyURZDB6thB90LSliWlf0ZM_rsWCTyUJNEpe_F-w"
 
             val request =
                 chain.request().newBuilder()

--- a/app/src/main/java/com/umc/product/di/AuthenticationInterceptor.kt
+++ b/app/src/main/java/com/umc/product/di/AuthenticationInterceptor.kt
@@ -25,8 +25,8 @@ class AuthenticationInterceptor @Inject constructor(
             }
 
             val accessToken = runBlocking { appDataStoreRepository.getAccessToken() }
-            val testToken = "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNzcxMzk4NDgwLCJleHAiOjE3" +
-                    "NzE0MDkyODB9.oAdVb1rRM7HFjzOmujDQYIK1HOHRZs3HjM5yZ-kM_ctMx4VSthmEzd2v8WaIMu96vJTueXxQ8P7cTAHv0D5zmg"
+            val testToken = "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNzcxNDAyMzIxLCJleHAiOjE3NzE0MT" +
+                    "MxMjF9.7KO-yzAlkZhODXe56VA2O5MRuvOEA2Q_ueUQs4LK2Nw6Cq_rWRp2RdlXcn4490_HlMXdGH3uK0iKEHFs35UkaQ"
 
             val request =
                 chain.request().newBuilder()

--- a/app/src/main/java/com/umc/product/di/AuthenticationInterceptor.kt
+++ b/app/src/main/java/com/umc/product/di/AuthenticationInterceptor.kt
@@ -25,8 +25,8 @@ class AuthenticationInterceptor @Inject constructor(
             }
 
             val accessToken = runBlocking { appDataStoreRepository.getAccessToken() }
-            val testToken = "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNzcxMjMwMDg3LCJleHAiO" +
-                    "jE3NzEyMzM2ODd9.23E-Le5CbMNca4ELv3OaFAvdredIwIUKpZPsRZZcfvBe8G1bdBvC1LuUd6LiJKdTaTCJysw16nOT38mtgBKjpw"
+            val testToken = "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNzcxMzE0MjQ1LCJleHAiOjE3NzEzMTc4NDV9.XGEY2D" +
+                    "giMKn_CVGCVHB3bvJJ5-V6p928Rk_qZwC6QtN-CkUUBqlZTrGYrPobvV_iw7Pt5y4D6Q8lfMBXe4fRlA"
 
             val request =
                 chain.request().newBuilder()

--- a/app/src/main/java/com/umc/product/di/AuthenticationInterceptor.kt
+++ b/app/src/main/java/com/umc/product/di/AuthenticationInterceptor.kt
@@ -25,8 +25,8 @@ class AuthenticationInterceptor @Inject constructor(
             }
 
             val accessToken = runBlocking { appDataStoreRepository.getAccessToken() }
-            val testToken = "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNzcxMzE0MjQ1LCJleHAiOjE3NzEzMTc4NDV9.XGEY2D" +
-                    "giMKn_CVGCVHB3bvJJ5-V6p928Rk_qZwC6QtN-CkUUBqlZTrGYrPobvV_iw7Pt5y4D6Q8lfMBXe4fRlA"
+            val testToken = "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNzcxMzE4MzYzLCJleHAiOjE3NzE" +
+                    "zMjE5NjN9.8YQWlPHjs_8k-BpDuoMjgizu5EelaSEx3wJQ3aJRmfW3Ck8idYRVE0vl6EHBh3b010IoByxHd21oxw2UBnpbeA"
 
             val request =
                 chain.request().newBuilder()

--- a/app/src/main/java/com/umc/product/di/AuthenticationInterceptor.kt
+++ b/app/src/main/java/com/umc/product/di/AuthenticationInterceptor.kt
@@ -25,8 +25,8 @@ class AuthenticationInterceptor @Inject constructor(
             }
 
             val accessToken = runBlocking { appDataStoreRepository.getAccessToken() }
-            val testToken = "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNzcxMzMzMTA" +
-                    "xLCJleHAiOjE3NzEzMzY3MDF9.aECNrnOmnYKSjqusLf5SsvwSDcmQQpoMduJhgQvz_LPAaEYyURZDB6thB90LSliWlf0ZM_rsWCTyUJNEpe_F-w"
+            val testToken = "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNzcxMzk0MDE5LCJleHAiO" +
+                    "jE3NzEzOTc2MTl9.S3eWPJmRcGDfjRoYmY_3pV4qPzlRynYZlXFvv4LaU4XoGM7tzyVQOEF3MIQBjxaTGhXVs0lprGAr8SAcJw6fnw"
 
             val request =
                 chain.request().newBuilder()

--- a/app/src/main/java/com/umc/product/di/DataSourceModule.kt
+++ b/app/src/main/java/com/umc/product/di/DataSourceModule.kt
@@ -7,6 +7,8 @@ import com.umc.data.dataSource.remote.AuthRemoteDataSourceImpl
 import com.umc.data.dataSource.remote.OrganizationRemoteDataSourceImpl
 import com.umc.data.dataSource.remote.attendance.AttendanceRemoteDataSource
 import com.umc.data.dataSource.remote.attendance.AttendanceRemoteDataSourceImpl
+import com.umc.data.dataSource.remote.authorize.AuthorizeRemoteDataSource
+import com.umc.data.dataSource.remote.authorize.AuthorizeRemoteDataSourceImpl
 import com.umc.data.dataSource.remote.kakao.KakaoRemoteDataSource
 import com.umc.data.dataSource.remote.kakao.KakaoRemoteDataSourceImpl
 import com.umc.data.dataSource.remote.member.MemberRemoteDataSource
@@ -78,4 +80,8 @@ abstract class DataSourceModule {
     @Singleton
     @Binds
     abstract fun bindsTermsRemoteDataSource(dataSourceImpl: TermsRemoteDataSourceImpl): TermsRemoteDataSource
+
+    @Singleton
+    @Binds
+    abstract fun bindsAuthorizeRemoteDataSource(dataSourceImpl: AuthorizeRemoteDataSourceImpl): AuthorizeRemoteDataSource
 }

--- a/app/src/main/java/com/umc/product/di/RepositoryModule.kt
+++ b/app/src/main/java/com/umc/product/di/RepositoryModule.kt
@@ -5,6 +5,7 @@ import com.umc.domain.repository.AppDataStoreRepository
 import com.umc.data.repository.AuthRepositoryImpl
 import com.umc.data.repository.OrganizationRepositoryImpl
 import com.umc.data.repository.attendance.AttendanceRepositoryImpl
+import com.umc.data.repository.authorize.AuthorizeRepositoryImpl
 import com.umc.data.repository.kakao.KakaoSearchRepositoryImpl
 import com.umc.data.repository.member.MemberRepositoryImpl
 import com.umc.domain.repository.AuthRepository
@@ -18,6 +19,7 @@ import com.umc.data.repository.terms.TermsRepositoryImpl
 import com.umc.domain.repository.ChallengerRepository
 import com.umc.domain.repository.OrganizationRepository
 import com.umc.domain.repository.attendance.AttendanceRepository
+import com.umc.domain.repository.authorize.AuthorizeRepository
 import com.umc.domain.repository.community.CommunityRepository
 import com.umc.domain.repository.schedule.ScheduleRepository
 import com.umc.domain.repository.storage.StorageRepository
@@ -88,5 +90,9 @@ abstract class RepositoryModule {
     @Singleton
     @Binds
     abstract fun bindsTermsRepository(repositoryImpl: TermsRepositoryImpl): TermsRepository
+
+    @Singleton
+    @Binds
+    abstract fun bindsAuthorizeRepository(repositoryImpl: AuthorizeRepositoryImpl): AuthorizeRepository
 
 }

--- a/data/src/main/java/com/umc/data/api/AuthApi.kt
+++ b/data/src/main/java/com/umc/data/api/AuthApi.kt
@@ -46,11 +46,5 @@ interface AuthApi {
     ): ApiResponse<EmailVerificationCompleteResponse>
 
 
-    @GET(Endpoints.Auth.AUTHORIZATION_CHECK)
-    suspend fun checkAuthAccess(
-        @Query("resourceType") resourceType: String,
-        @Query("resourceId") resourceId: Long
-    ): ApiResponse<AuthorAccessResponse>
-
 
 }

--- a/data/src/main/java/com/umc/data/api/AuthApi.kt
+++ b/data/src/main/java/com/umc/data/api/AuthApi.kt
@@ -4,6 +4,7 @@ import com.umc.data.response.EmailVerificationCompleteResponse
 import com.umc.data.response.EmailVerificationResponse
 import com.umc.data.response.JwtLoginResponse
 import com.umc.data.response.RefreshTokenResponse
+import com.umc.data.response.authorization.AuthorAccessResponse
 import com.umc.domain.model.base.ApiResponse
 import com.umc.domain.model.base.ApiState
 import com.umc.domain.model.request.EmailVerificationCompleteRequest
@@ -12,8 +13,10 @@ import com.umc.domain.model.request.LoginGoogleRequest
 import com.umc.domain.model.request.LoginKakaoRequest
 import com.umc.domain.model.request.RefreshTokenRequest
 import retrofit2.http.Body
+import retrofit2.http.GET
 import retrofit2.http.Header
 import retrofit2.http.POST
+import retrofit2.http.Query
 
 interface AuthApi {
     @POST(Endpoints.Auth.REISSUE)
@@ -41,5 +44,13 @@ interface AuthApi {
     suspend fun emailVerificationComplete(
         @Body request: EmailVerificationCompleteRequest
     ): ApiResponse<EmailVerificationCompleteResponse>
+
+
+    @GET(Endpoints.Auth.AUTHORIZATION_CHECK)
+    suspend fun checkAuthAccess(
+        @Query("resourceType") resourceType: String,
+        @Query("resourceId") resourceId: Long
+    ): ApiResponse<AuthorAccessResponse>
+
 
 }

--- a/data/src/main/java/com/umc/data/api/AuthorizeApi.kt
+++ b/data/src/main/java/com/umc/data/api/AuthorizeApi.kt
@@ -1,0 +1,16 @@
+package com.umc.data.api
+
+import com.umc.data.response.authorization.AuthorAccessResponse
+import com.umc.domain.model.base.ApiResponse
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+interface AuthorizeApi {
+
+    @GET(Endpoints.Auth.AUTHORIZATION_CHECK)
+    suspend fun checkAuthAccess(
+        @Query("resourceType") resourceType: String,
+        @Query("resourceId") resourceId: Long
+    ): ApiResponse<AuthorAccessResponse>
+
+}

--- a/data/src/main/java/com/umc/data/api/CommunityApi.kt
+++ b/data/src/main/java/com/umc/data/api/CommunityApi.kt
@@ -137,4 +137,17 @@ interface CommunityApi {
         @Query("size") size: Int = 20 // 페이지당 개수
     ): ApiResponse<CommunityGetPostResponse>
 
+    //게시글 신고
+    @POST(Endpoints.Community.REPORT_POST)
+    suspend fun reportPost(
+        @Path("postId") postId: Long
+    ): ApiResponse<Unit>
+
+    //댓글 신고
+    @POST(Endpoints.Community.REPORT_COMMENT)
+    suspend fun reportComment(
+        @Path("commentId") commentId: Long
+    ): ApiResponse<Unit>
+
+
 }

--- a/data/src/main/java/com/umc/data/api/Endpoints.kt
+++ b/data/src/main/java/com/umc/data/api/Endpoints.kt
@@ -81,6 +81,11 @@ object Endpoints {
 
         const val MODIFY_LIGHTNING = "$COMMUNITY/{postId}/lightning"
 
+        const val REPORT_POST = "$COMMUNITY/{postId}/reports"
+
+        const val REPORT_COMMENT = "api/v1/comments/{commentId}/reports"
+
+
 
 
     }

--- a/data/src/main/java/com/umc/data/api/Endpoints.kt
+++ b/data/src/main/java/com/umc/data/api/Endpoints.kt
@@ -73,7 +73,7 @@ object Endpoints {
         const val MY_COMMENT = "$COMMUNITY/commented"
         const val MY_SCRAP = "$COMMUNITY/scrapped"
 
-        const val MODIFY_LIGHTNING = "$COMMUNITY/{postId}lightning"
+        const val MODIFY_LIGHTNING = "$COMMUNITY/{postId}/lightning"
 
 
 

--- a/data/src/main/java/com/umc/data/api/Endpoints.kt
+++ b/data/src/main/java/com/umc/data/api/Endpoints.kt
@@ -3,12 +3,18 @@ package com.umc.data.api
 object Endpoints {
 
     object Auth {
+        //Authentication
         const val AUTH = "api/v1/auth"
         const val REISSUE = "$AUTH/auth/renew"
         const val LOGIN_KAKAO = "$AUTH/login/kakao"
         const val LOGIN_GOOGLE = "$AUTH/login/google"
         const val EMAIL_VERIFICATION = "$AUTH/email-verification"
         const val EMAIL_VERIFICATION_COMPLETE = "$EMAIL_VERIFICATION/code"
+
+        //Authorization
+        const val AUTHORIZATION = "api/v1/authorization"
+        const val AUTHORIZATION_CHECK = "$AUTHORIZATION/resource-permission"
+
     }
 
     object Attendance {
@@ -119,4 +125,5 @@ object Endpoints {
         const val TERMS_TYPE = "$TERMS/type/{termsType}"
         const val TERMS_ID = "$TERMS/{termsId}"
     }
+
 }

--- a/data/src/main/java/com/umc/data/dataSource/AuthRemoteDataSource.kt
+++ b/data/src/main/java/com/umc/data/dataSource/AuthRemoteDataSource.kt
@@ -4,6 +4,7 @@ import com.umc.data.response.EmailVerificationCompleteResponse
 import com.umc.data.response.EmailVerificationResponse
 import com.umc.data.response.JwtLoginResponse
 import com.umc.data.response.RefreshTokenResponse
+import com.umc.data.response.authorization.AuthorAccessResponse
 import com.umc.domain.model.base.ApiState
 import com.umc.domain.model.request.EmailVerificationCompleteRequest
 import com.umc.domain.model.request.EmailVerificationRequest
@@ -17,4 +18,5 @@ interface AuthRemoteDataSource {
     suspend fun loginGoogle(request: LoginGoogleRequest): ApiState<JwtLoginResponse>
     suspend fun emailVerify(request: EmailVerificationRequest): ApiState<EmailVerificationResponse>
     suspend fun emailVerifyComplete(request: EmailVerificationCompleteRequest): ApiState<EmailVerificationCompleteResponse>
+    suspend fun checkAuthAccess(resourceType: String, resourceId: Long): ApiState<AuthorAccessResponse>
 }

--- a/data/src/main/java/com/umc/data/dataSource/AuthRemoteDataSource.kt
+++ b/data/src/main/java/com/umc/data/dataSource/AuthRemoteDataSource.kt
@@ -18,5 +18,4 @@ interface AuthRemoteDataSource {
     suspend fun loginGoogle(request: LoginGoogleRequest): ApiState<JwtLoginResponse>
     suspend fun emailVerify(request: EmailVerificationRequest): ApiState<EmailVerificationResponse>
     suspend fun emailVerifyComplete(request: EmailVerificationCompleteRequest): ApiState<EmailVerificationCompleteResponse>
-    suspend fun checkAuthAccess(resourceType: String, resourceId: Long): ApiState<AuthorAccessResponse>
 }

--- a/data/src/main/java/com/umc/data/dataSource/remote/AuthRemoteDataSourceImpl.kt
+++ b/data/src/main/java/com/umc/data/dataSource/remote/AuthRemoteDataSourceImpl.kt
@@ -7,6 +7,7 @@ import com.umc.data.response.EmailVerificationCompleteResponse
 import com.umc.data.response.EmailVerificationResponse
 import com.umc.data.response.JwtLoginResponse
 import com.umc.data.response.RefreshTokenResponse
+import com.umc.data.response.authorization.AuthorAccessResponse
 import com.umc.domain.model.base.ApiState
 import com.umc.domain.model.request.EmailVerificationCompleteRequest
 import com.umc.domain.model.request.EmailVerificationRequest
@@ -37,5 +38,10 @@ class AuthRemoteDataSourceImpl @Inject constructor(
 
     override suspend fun emailVerifyComplete(request: EmailVerificationCompleteRequest): ApiState<EmailVerificationCompleteResponse> {
         return apiCall { authApi.emailVerificationComplete(request = request) }
+    }
+
+    override suspend fun checkAuthAccess(resourceType: String, resourceId: Long
+    ): ApiState<AuthorAccessResponse> {
+        return apiCall { authApi.checkAuthAccess(resourceType, resourceId) }
     }
 }

--- a/data/src/main/java/com/umc/data/dataSource/remote/AuthRemoteDataSourceImpl.kt
+++ b/data/src/main/java/com/umc/data/dataSource/remote/AuthRemoteDataSourceImpl.kt
@@ -40,8 +40,4 @@ class AuthRemoteDataSourceImpl @Inject constructor(
         return apiCall { authApi.emailVerificationComplete(request = request) }
     }
 
-    override suspend fun checkAuthAccess(resourceType: String, resourceId: Long
-    ): ApiState<AuthorAccessResponse> {
-        return apiCall { authApi.checkAuthAccess(resourceType, resourceId) }
-    }
 }

--- a/data/src/main/java/com/umc/data/dataSource/remote/authorize/AuthorizeRemoteDataSource.kt
+++ b/data/src/main/java/com/umc/data/dataSource/remote/authorize/AuthorizeRemoteDataSource.kt
@@ -1,0 +1,8 @@
+package com.umc.data.dataSource.remote.authorize
+
+import com.umc.data.response.authorization.AuthorAccessResponse
+import com.umc.domain.model.base.ApiState
+
+interface AuthorizeRemoteDataSource {
+    suspend fun checkAuthAccess(resourceType: String, resourceId: Long): ApiState<AuthorAccessResponse>
+}

--- a/data/src/main/java/com/umc/data/dataSource/remote/authorize/AuthorizeRemoteDataSourceImpl.kt
+++ b/data/src/main/java/com/umc/data/dataSource/remote/authorize/AuthorizeRemoteDataSourceImpl.kt
@@ -1,0 +1,17 @@
+package com.umc.data.dataSource.remote.authorize
+
+import com.umc.data.api.AuthorizeApi
+import com.umc.data.dataSource.base.apiCall
+import com.umc.data.response.authorization.AuthorAccessResponse
+import com.umc.domain.model.base.ApiState
+import javax.inject.Inject
+
+class AuthorizeRemoteDataSourceImpl @Inject constructor(
+    private val authorizeApi: AuthorizeApi,
+) : AuthorizeRemoteDataSource{
+
+    override suspend fun checkAuthAccess(resourceType: String, resourceId: Long
+    ): ApiState<AuthorAccessResponse> {
+        return apiCall { authorizeApi.checkAuthAccess(resourceType, resourceId) }
+    }
+}

--- a/data/src/main/java/com/umc/data/dataSource/remote/community/CommunityRemoteDataSource.kt
+++ b/data/src/main/java/com/umc/data/dataSource/remote/community/CommunityRemoteDataSource.kt
@@ -62,4 +62,9 @@ interface CommunityRemoteDataSource {
     //내가 스크랩 한 글 가져오기
     suspend fun getMyScrappedPosts(page: Int, size: Int = 20): ApiState<CommunityGetPostResponse>
 
+    //게시글 신고
+    suspend fun reportPost(postId: Long): ApiState<Unit>
+
+    //댓글 신고
+    suspend fun reportComment(commentId: Long): ApiState<Unit>
 }

--- a/data/src/main/java/com/umc/data/dataSource/remote/community/CommunityRemoteDataSourceImpl.kt
+++ b/data/src/main/java/com/umc/data/dataSource/remote/community/CommunityRemoteDataSourceImpl.kt
@@ -119,4 +119,14 @@ class CommunityRemoteDataSourceImpl @Inject constructor(
 
     }
 
+    //게시글 신고
+    override suspend fun reportPost(postId: Long): ApiState<Unit> {
+        return apiCall { communityApi.reportPost(postId) }
+    }
+
+    //댓글 신고
+    override suspend fun reportComment(commentId: Long): ApiState<Unit> {
+        return apiCall { communityApi.reportComment(commentId) }
+    }
+
 }

--- a/data/src/main/java/com/umc/data/repository/AuthRepositoryImpl.kt
+++ b/data/src/main/java/com/umc/data/repository/AuthRepositoryImpl.kt
@@ -5,6 +5,8 @@ import com.umc.data.response.EmailVerificationCompleteResponse.Companion.toModel
 import com.umc.data.response.EmailVerificationResponse.Companion.toModel
 import com.umc.data.response.JwtLoginResponse.Companion.toModel
 import com.umc.data.response.RefreshTokenResponse.Companion.toModel
+import com.umc.data.response.authorization.AuthorAccessResponse.Companion.toModel
+import com.umc.domain.model.AuthorAccess
 import com.umc.domain.model.base.ApiState
 import com.umc.domain.model.JwtToken
 import com.umc.domain.model.base.map
@@ -47,5 +49,13 @@ class AuthRepositoryImpl @Inject constructor(
         return authRemoteDataSource.emailVerifyComplete(request).map {
             it.toModel()
         }
+    }
+
+    override suspend fun checkAuthAccess(resourceType: String, resourceId: Long
+    ): ApiState<AuthorAccess> {
+        return authRemoteDataSource.checkAuthAccess(resourceType, resourceId).map {
+            it.toModel()
+        }
+
     }
 }

--- a/data/src/main/java/com/umc/data/repository/AuthRepositoryImpl.kt
+++ b/data/src/main/java/com/umc/data/repository/AuthRepositoryImpl.kt
@@ -51,11 +51,5 @@ class AuthRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun checkAuthAccess(resourceType: String, resourceId: Long
-    ): ApiState<AuthorAccess> {
-        return authRemoteDataSource.checkAuthAccess(resourceType, resourceId).map {
-            it.toModel()
-        }
 
-    }
 }

--- a/data/src/main/java/com/umc/data/repository/authorize/AuthorizeRepositoryImpl.kt
+++ b/data/src/main/java/com/umc/data/repository/authorize/AuthorizeRepositoryImpl.kt
@@ -1,0 +1,21 @@
+package com.umc.data.repository.authorize
+
+import com.umc.data.dataSource.remote.authorize.AuthorizeRemoteDataSource
+import com.umc.data.response.authorization.AuthorAccessResponse.Companion.toModel
+import com.umc.domain.model.AuthorAccess
+import com.umc.domain.model.base.ApiState
+import com.umc.domain.model.base.map
+import com.umc.domain.repository.authorize.AuthorizeRepository
+import javax.inject.Inject
+
+class AuthorizeRepositoryImpl @Inject constructor(
+    private val authorizeRemoteDataSource: AuthorizeRemoteDataSource
+) : AuthorizeRepository {
+
+    override suspend fun checkAuthAccess(resourceType: String, resourceId: Long
+    ): ApiState<AuthorAccess> {
+        return authorizeRemoteDataSource.checkAuthAccess(resourceType, resourceId).map {
+            it.toModel()
+        }
+    }
+}

--- a/data/src/main/java/com/umc/data/repository/community/CommunityRepositoryImpl.kt
+++ b/data/src/main/java/com/umc/data/repository/community/CommunityRepositoryImpl.kt
@@ -143,4 +143,14 @@ class CommunityRepositoryImpl @Inject constructor(
             it.toPostPageModelDomain() }
     }
 
+    //게시글 신고
+    override suspend fun reportPost(postId: Long): ApiState<Unit> {
+        return communityRemoteDataSource.reportPost(postId)
+    }
+
+    //댓글 신고
+    override suspend fun reportComment(commentId: Long): ApiState<Unit> {
+        return communityRemoteDataSource.reportComment(commentId)
+    }
+
 }

--- a/data/src/main/java/com/umc/data/response/authorization/AuthorAccessResponse.kt
+++ b/data/src/main/java/com/umc/data/response/authorization/AuthorAccessResponse.kt
@@ -1,0 +1,45 @@
+package com.umc.data.response.authorization
+
+import com.google.gson.annotations.SerializedName
+import com.umc.data.response.authorization.PermissionItemResponse.Companion.toModel
+import com.umc.domain.model.AuthorAccess
+import com.umc.domain.model.PermissionItem
+import com.umc.domain.model.enums.PermissionType
+import com.umc.domain.model.enums.ResourceType
+
+data class AuthorAccessResponse (
+    @SerializedName("resourceType")
+    val resourceType: String,
+    @SerializedName("resourceId")
+    val resourceId: Long,
+    @SerializedName("permissions")
+    val permissions: List<PermissionItemResponse>
+) {
+    companion object {
+        fun AuthorAccessResponse.toModel(): AuthorAccess {
+            return AuthorAccess(
+                resourceType = runCatching { ResourceType.valueOf(this.resourceType) }
+                    .getOrDefault(ResourceType.SCHEDULE),
+                resourceId = this.resourceId,
+                permissions = this.permissions.map { it.toModel() }
+            )
+        }
+    }
+}
+
+data class PermissionItemResponse(
+    @SerializedName("permissionType")
+    val permissionType: String,
+    @SerializedName("hasPermission")
+    val hasPermission: Boolean
+) {
+    companion object {
+        fun PermissionItemResponse.toModel(): PermissionItem {
+            return PermissionItem(
+                type = runCatching { PermissionType.valueOf(this.permissionType) }
+                    .getOrDefault(PermissionType.READ),
+                hasPermission = this.hasPermission
+            )
+        }
+    }
+}

--- a/domain/src/main/java/com/umc/domain/model/AuthorAccess.kt
+++ b/domain/src/main/java/com/umc/domain/model/AuthorAccess.kt
@@ -1,0 +1,18 @@
+package com.umc.domain.model
+
+import com.umc.domain.model.enums.PermissionType
+import com.umc.domain.model.enums.ResourceType
+
+data class AuthorAccess(
+    val resourceType: ResourceType, // Enum으로 관리하여 오타 방지
+    val resourceId: Long,
+    val permissions: List<PermissionItem>
+)
+
+/**
+ * 개별 권한 항목 도메인 모델
+ */
+data class PermissionItem(
+    val type: PermissionType, // READ, WRITE 등 Enum
+    val hasPermission: Boolean
+)

--- a/domain/src/main/java/com/umc/domain/model/enums/PermissionType.kt
+++ b/domain/src/main/java/com/umc/domain/model/enums/PermissionType.kt
@@ -1,0 +1,11 @@
+package com.umc.domain.model.enums
+
+//리소스 접근 권한 확인용 조회 시 권한 유형 (ResourceType하고 연관)
+enum class PermissionType {
+    READ,
+    WRITE,
+    DELETE,
+    APPROVE,
+    CHECK,
+    MANAGE
+}

--- a/domain/src/main/java/com/umc/domain/model/enums/PermissionType.kt
+++ b/domain/src/main/java/com/umc/domain/model/enums/PermissionType.kt
@@ -4,6 +4,7 @@ package com.umc.domain.model.enums
 enum class PermissionType {
     READ,
     WRITE,
+    EDIT,
     DELETE,
     APPROVE,
     CHECK,

--- a/domain/src/main/java/com/umc/domain/model/enums/ResourceType.kt
+++ b/domain/src/main/java/com/umc/domain/model/enums/ResourceType.kt
@@ -1,0 +1,13 @@
+package com.umc.domain.model.enums
+
+//리소스 접근 권한 확인용 enum
+enum class ResourceType {
+    CURRICULUM,          //커리큘럼
+    SCHEDULE,            //일정
+    NOTICE,              //공지
+    CHAPTER,             //
+    WORKBOOK_SUBMISSION, //
+    ATTENDANCE_SHEET,    //
+    ATTENDANCE_RECORD,   //
+    UNKNOWN
+}

--- a/domain/src/main/java/com/umc/domain/model/enums/ResourceType.kt
+++ b/domain/src/main/java/com/umc/domain/model/enums/ResourceType.kt
@@ -9,5 +9,8 @@ enum class ResourceType {
     WORKBOOK_SUBMISSION, //
     ATTENDANCE_SHEET,    //
     ATTENDANCE_RECORD,   //
+    COMMUNITY_POST, //
+    COMMUNITY_COMMENT, //
+
     UNKNOWN
 }

--- a/domain/src/main/java/com/umc/domain/model/enums/UserChallengerRole.kt
+++ b/domain/src/main/java/com/umc/domain/model/enums/UserChallengerRole.kt
@@ -1,19 +1,20 @@
 package com.umc.domain.model.enums
 
 enum class UserChallengerRole(val displayName: String?, val isVisible: Boolean) {
-    SUPER_ADMIN(null, false),
-    CENTRAL_PRESIDENT(null, false),
-    CENTRAL_VICE_PRESIDENT(null, false),
-    CENTRAL_OPERATING_TEAM_MEMBER(null, false),
-    CENTRAL_EDUCATION_TEAM_MEMBER(null, false),
-    CHAPTER_PRESIDENT(null, false),
+    SUPER_ADMIN("시스템 관리자", false),
+    CENTRAL_PRESIDENT("중앙운영사무국 총괄", false),
+    CENTRAL_VICE_PRESIDENT("중앙운영사무국 부총괄", false),
+    CENTRAL_OPERATING_TEAM_MEMBER("중앙운영사무국 운영국", false),
+    CENTRAL_EDUCATION_TEAM_MEMBER("중앙운영사무국 교육국", false),
+    CHAPTER_PRESIDENT("지부장", false),
 
     // UI에 표시할 역할들
-    SCHOOL_PRESIDENT("학교 회장", true),
-    SCHOOL_VICE_PRESIDENT("부회장", true),
-    SCHOOL_PART_LEADER("파트장", true),
+    SCHOOL_PRESIDENT("교내 회장", true),
+    SCHOOL_VICE_PRESIDENT("교내 부회장", true),
+    SCHOOL_PART_LEADER("교내 파트장", true),
 
-    SCHOOL_ETC_ADMIN(null, false),
+    SCHOOL_ETC_ADMIN("교내 운영진", false),
+    CHALLENGER("챌린저", false),
     MEMBER(null, false); // 기본값
 
     companion object {

--- a/domain/src/main/java/com/umc/domain/model/home/UserInfoParseItem.kt
+++ b/domain/src/main/java/com/umc/domain/model/home/UserInfoParseItem.kt
@@ -6,12 +6,14 @@ import com.umc.domain.model.UserInfo
 /**
  * 해당 data class는 UserInfo를 바탕으로 역할이랑 기수 등을 파싱해 저장하는
  * 클래스입니다. 주로 UI 작업에 사용하며, 최신 기수나 challengerId를 얻는데 사용합니다.
+ *
+ * @param UserChallengerRole 을 RolePartItem의 role에서 from으로 이용해 찾아본다.
  * **/
 
 // 1. 개별 활동 아이템 (역할, 파트, 그리고 챌린저 ID)
 data class RolePartItem(
-    val role: String,
-    val responsiblePart: String?,
+    val role: String, //역할 (SCHOOL_PART_LEADER)
+    val responsiblePart: String?, //ANDROID ...
     val challengerId: Long
 )
 

--- a/domain/src/main/java/com/umc/domain/repository/AuthRepository.kt
+++ b/domain/src/main/java/com/umc/domain/repository/AuthRepository.kt
@@ -15,5 +15,5 @@ interface AuthRepository {
     suspend fun googleLogin(request: LoginGoogleRequest): ApiState<JwtToken>
     suspend fun emailVerify(request: EmailVerificationRequest): ApiState<String>
     suspend fun emailVerifyComplete(request: EmailVerificationCompleteRequest): ApiState<String>
-    suspend fun checkAuthAccess(resourceType: String, resourceId: Long): ApiState<AuthorAccess>
+
 }

--- a/domain/src/main/java/com/umc/domain/repository/AuthRepository.kt
+++ b/domain/src/main/java/com/umc/domain/repository/AuthRepository.kt
@@ -1,5 +1,6 @@
 package com.umc.domain.repository
 
+import com.umc.domain.model.AuthorAccess
 import com.umc.domain.model.base.ApiState
 import com.umc.domain.model.JwtToken
 import com.umc.domain.model.request.EmailVerificationCompleteRequest
@@ -14,4 +15,5 @@ interface AuthRepository {
     suspend fun googleLogin(request: LoginGoogleRequest): ApiState<JwtToken>
     suspend fun emailVerify(request: EmailVerificationRequest): ApiState<String>
     suspend fun emailVerifyComplete(request: EmailVerificationCompleteRequest): ApiState<String>
+    suspend fun checkAuthAccess(resourceType: String, resourceId: Long): ApiState<AuthorAccess>
 }

--- a/domain/src/main/java/com/umc/domain/repository/authorize/AuthorizeRepository.kt
+++ b/domain/src/main/java/com/umc/domain/repository/authorize/AuthorizeRepository.kt
@@ -1,0 +1,8 @@
+package com.umc.domain.repository.authorize
+
+import com.umc.domain.model.AuthorAccess
+import com.umc.domain.model.base.ApiState
+
+interface AuthorizeRepository {
+    suspend fun checkAuthAccess(resourceType: String, resourceId: Long): ApiState<AuthorAccess>
+}

--- a/domain/src/main/java/com/umc/domain/repository/community/CommunityRepository.kt
+++ b/domain/src/main/java/com/umc/domain/repository/community/CommunityRepository.kt
@@ -62,5 +62,10 @@ interface CommunityRepository {
     //내가 스크랩 한 글 갖고오기
     suspend fun getMyScrappedPosts(page: Int, size: Int): ApiState<PostPageModel>
 
+    //게시글 신고
+    suspend fun reportPost(postId: Long): ApiState<Unit>
+
+    //댓글 신고
+    suspend fun reportComment(commentId: Long): ApiState<Unit>
 }
 

--- a/domain/src/main/java/com/umc/domain/usecase/GetAuthAccessUseCase.kt
+++ b/domain/src/main/java/com/umc/domain/usecase/GetAuthAccessUseCase.kt
@@ -1,0 +1,24 @@
+package com.umc.domain.usecase
+
+import com.umc.domain.model.AuthorAccess
+import com.umc.domain.model.base.ApiState
+import com.umc.domain.model.enums.ResourceType
+import com.umc.domain.repository.AuthRepository
+import javax.inject.Inject
+
+
+/**
+ * @param resourceType은 ResourceType enum을 사용
+ * @param resourceId는 리소스의 고유 식별자 - ex. 일정 id, 커리큘럼 id 등
+ * **/
+
+//리소스 권한 조회 usecase
+class GetAuthAccessUseCase @Inject constructor(
+    private val authRepository: AuthRepository
+) {
+    suspend operator fun invoke(resourceType: ResourceType, resourceId: Long): ApiState<AuthorAccess> {
+        val resourceTypeString = resourceType.name
+        return authRepository.checkAuthAccess(resourceTypeString, resourceId)
+    }
+
+}

--- a/domain/src/main/java/com/umc/domain/usecase/GetAuthAccessUseCase.kt
+++ b/domain/src/main/java/com/umc/domain/usecase/GetAuthAccessUseCase.kt
@@ -3,7 +3,7 @@ package com.umc.domain.usecase
 import com.umc.domain.model.AuthorAccess
 import com.umc.domain.model.base.ApiState
 import com.umc.domain.model.enums.ResourceType
-import com.umc.domain.repository.AuthRepository
+import com.umc.domain.repository.authorize.AuthorizeRepository
 import javax.inject.Inject
 
 
@@ -14,11 +14,11 @@ import javax.inject.Inject
 
 //리소스 권한 조회 usecase
 class GetAuthAccessUseCase @Inject constructor(
-    private val authRepository: AuthRepository
+    private val authorizeRepository: AuthorizeRepository
 ) {
     suspend operator fun invoke(resourceType: ResourceType, resourceId: Long): ApiState<AuthorAccess> {
         val resourceTypeString = resourceType.name
-        return authRepository.checkAuthAccess(resourceTypeString, resourceId)
+        return authorizeRepository.checkAuthAccess(resourceTypeString, resourceId)
     }
 
 }

--- a/domain/src/main/java/com/umc/domain/usecase/GetChallengerIdUseCase.kt
+++ b/domain/src/main/java/com/umc/domain/usecase/GetChallengerIdUseCase.kt
@@ -1,0 +1,4 @@
+package com.umc.domain.usecase
+
+class GetChallengerIdUseCase {
+}

--- a/domain/src/main/java/com/umc/domain/usecase/GetChallengerIdUseCase.kt
+++ b/domain/src/main/java/com/umc/domain/usecase/GetChallengerIdUseCase.kt
@@ -1,4 +1,28 @@
 package com.umc.domain.usecase
 
-class GetChallengerIdUseCase {
+import com.umc.domain.model.home.getGisuSummaryList
+import com.umc.domain.repository.AppDataStoreRepository
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+//유저의 가장 최신 challengerId를 가져오는 usecase
+class GetChallengerIdUseCase @Inject constructor(
+    private val repository: AppDataStoreRepository
+){
+    suspend operator fun invoke(): Long {
+        val userInfo = repository.getUserInfo().first()
+
+        val gisuSummaryList = userInfo.getGisuSummaryList()
+
+        //최신 기수 가져오기
+        val latestGisu = gisuSummaryList.maxByOrNull { it.gisu }
+
+        val challengerId = latestGisu?.let { summary ->
+            summary.fromRoles.firstOrNull()?.challengerId
+                ?: summary.fromRecords.firstOrNull()?.challengerId
+        }
+
+        return challengerId ?: -1L
+    }
 }

--- a/domain/src/main/java/com/umc/domain/usecase/community/ReportCommentUseCase.kt
+++ b/domain/src/main/java/com/umc/domain/usecase/community/ReportCommentUseCase.kt
@@ -1,0 +1,10 @@
+package com.umc.domain.usecase.community
+
+import com.umc.domain.repository.community.CommunityRepository
+import javax.inject.Inject
+
+class ReportCommentUseCase @Inject constructor(
+    private val communityRepository: CommunityRepository
+) {
+    suspend operator fun invoke(commentId: Long) = communityRepository.reportComment(commentId)
+}

--- a/domain/src/main/java/com/umc/domain/usecase/community/ReportPostUseCase.kt
+++ b/domain/src/main/java/com/umc/domain/usecase/community/ReportPostUseCase.kt
@@ -1,0 +1,10 @@
+package com.umc.domain.usecase.community
+
+import com.umc.domain.repository.community.CommunityRepository
+import javax.inject.Inject
+
+class ReportPostUseCase @Inject constructor(
+    private val communityRepository: CommunityRepository
+) {
+    suspend operator fun invoke(postId: Long) = communityRepository.reportPost(postId)
+}

--- a/presentation/src/main/java/com/umc/presentation/ui/community/detail/PostDetailFragment.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/community/detail/PostDetailFragment.kt
@@ -70,7 +70,7 @@ class PostDetailFragment : BaseFragment<FragmentPostDetailBinding, PostDetailFra
         menuBinding.layoutMenuReport.setOnClickListener {
             popup.dismiss()
             // 아까 만든 신고 다이얼로그 띄우기
-            handleEvent(PostDetailFragmentEvent.ReportComment)
+            handleEvent(PostDetailFragmentEvent.ReportComment(item.commentId))
         }
 
         // 삭제
@@ -172,7 +172,8 @@ class PostDetailFragment : BaseFragment<FragmentPostDetailBinding, PostDetailFra
                 UBasicDialog(
                     model = reportModel,
                     onConfirm = {
-                        // TODO: 서버에 신고 API 호출하는 뷰모델 함수 연결
+                        //서버에 신고
+                        viewModel.reportPost()
                     }
                 ).show(childFragmentManager, "ReportDialog")
             }
@@ -212,7 +213,8 @@ class PostDetailFragment : BaseFragment<FragmentPostDetailBinding, PostDetailFra
                 UBasicDialog(
                     model = reportModel,
                     onConfirm = {
-                        // TODO: 서버에 신고 API 호출하는 뷰모델 함수 연결
+                        // 서버에 신고
+                        viewModel.reportComment(event.commentId)
                     }
                 ).show(childFragmentManager, "ReportDialog")
             }

--- a/presentation/src/main/java/com/umc/presentation/ui/community/detail/PostDetailFragment.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/community/detail/PostDetailFragment.kt
@@ -61,7 +61,7 @@ class PostDetailFragment : BaseFragment<FragmentPostDetailBinding, PostDetailFra
         }
 
         // TODO : chllengerId 체크 필요!
-        val isMyComment = item.challengerId == viewModel.uiState.value.myId
+        val isMyComment = item.challengerId == viewModel.uiState.value.myChallengerId
         menuBinding.layoutMenuReport.visibility = if (isMyComment) View.GONE else View.VISIBLE
         menuBinding.layoutMenuDelete.visibility = if (isMyComment) View.VISIBLE else View.GONE
 

--- a/presentation/src/main/java/com/umc/presentation/ui/community/detail/PostDetailFragment.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/community/detail/PostDetailFragment.kt
@@ -47,48 +47,8 @@ class PostDetailFragment : BaseFragment<FragmentPostDetailBinding, PostDetailFra
 
     //댓글의 메뉴 클릭
     override fun onCommentMenuClicked(item: CommentItem) {
-        val inflater = LayoutInflater.from(requireContext())
-        val menuBinding = LayoutMenuCommentBinding.inflate(inflater)
-
-        // PopupWindow 설정
-        val popup = PopupWindow(
-            menuBinding.root,
-            LinearLayout.LayoutParams.WRAP_CONTENT,
-            LinearLayout.LayoutParams.WRAP_CONTENT,
-            true // 바깥쪽 터치 시 닫힘
-        ).apply {
-            elevation = 20f
-        }
-
-        // TODO : chllengerId 체크 필요!
-        val isMyComment = item.challengerId == viewModel.uiState.value.myChallengerId
-        menuBinding.layoutMenuReport.visibility = if (isMyComment) View.GONE else View.VISIBLE
-        menuBinding.layoutMenuDelete.visibility = if (isMyComment) View.VISIBLE else View.GONE
-
-        // 메뉴 클릭 이벤트
-        // 신고
-        menuBinding.layoutMenuReport.setOnClickListener {
-            popup.dismiss()
-            // 아까 만든 신고 다이얼로그 띄우기
-            handleEvent(PostDetailFragmentEvent.ReportComment(item.commentId))
-        }
-
-        // 삭제
-        menuBinding.layoutMenuDelete.setOnClickListener {
-            popup.dismiss()
-            // 삭제 로직
-            viewModel.onClickeDeleteComment(item)
-
-        }
-
-        // 버튼 위치를 기준으로 띄우기 (약간의 오프셋 조정 가능)
-        val anchor = binding.postdetailRcv.findViewHolderForAdapterPosition(
-            postDetailAdapter.currentList.indexOf(PostDetailItem.Comment(item))
-        )?.itemView?.findViewById<View>(R.id.item_btn_menu)
-
-        anchor?.let {
-            popup.showAsDropDown(it, -250, +25) // 버튼 왼쪽 아래로 정렬
-        }
+        //권한 조회하러 가기
+        viewModel.onCommentMenuClicked(item)
     }
 
 
@@ -219,6 +179,13 @@ class PostDetailFragment : BaseFragment<FragmentPostDetailBinding, PostDetailFra
                 ).show(childFragmentManager, "ReportDialog")
             }
 
+            //댓글 메뉴 보여주기(권한 바탕으로)
+            is PostDetailFragmentEvent.ShowCommentMenu -> {
+                showCommentPopupMenu(event.item, event.canDelete)
+            }
+
+
+            //에러 토스트 출력
             is PostDetailFragmentEvent.ShowErrorToast -> {
                 Toast.makeText(requireContext(), event.errorMessage, Toast.LENGTH_SHORT).show()
             }
@@ -234,6 +201,40 @@ class PostDetailFragment : BaseFragment<FragmentPostDetailBinding, PostDetailFra
     }
 
 
+    //댓글 메뉴 눌렀을 때 처리하기 (실제 권한을 바탕을 로직 분리)
+    private fun showCommentPopupMenu(item: CommentItem, canDelete: Boolean) {
+        val inflater = LayoutInflater.from(requireContext())
+        val menuBinding = LayoutMenuCommentBinding.inflate(inflater)
+
+        val popup = PopupWindow(
+            menuBinding.root,
+            LinearLayout.LayoutParams.WRAP_CONTENT,
+            LinearLayout.LayoutParams.WRAP_CONTENT,
+            true
+        ).apply { elevation = 20f }
+
+        // 서버에서 받은 canDelete 결과에 따라 UI 가시성 조절
+        menuBinding.layoutMenuReport.visibility = if (canDelete) View.GONE else View.VISIBLE
+        menuBinding.layoutMenuDelete.visibility = if (canDelete) View.VISIBLE else View.GONE
+
+        // 메뉴 클릭 이벤트
+        menuBinding.layoutMenuReport.setOnClickListener {
+            popup.dismiss()
+            handleEvent(PostDetailFragmentEvent.ReportComment(item.commentId))
+        }
+
+        menuBinding.layoutMenuDelete.setOnClickListener {
+            popup.dismiss()
+            viewModel.onClickeDeleteComment(item) // 삭제 로직 실행
+        }
+
+        // 앵커 뷰 찾기 및 팝업 노출
+        val anchor = binding.postdetailRcv.findViewHolderForAdapterPosition(
+            postDetailAdapter.currentList.indexOf(PostDetailItem.Comment(item))
+        )?.itemView?.findViewById<View>(R.id.item_btn_menu)
+
+        anchor?.let { popup.showAsDropDown(it, -250, +25) }
+    }
 
 
     private fun handleKebabAnimation(isVisible: Boolean) {

--- a/presentation/src/main/java/com/umc/presentation/ui/community/detail/PostDetailViewModel.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/community/detail/PostDetailViewModel.kt
@@ -10,6 +10,9 @@ import com.umc.domain.model.enums.RecruitType
 import com.umc.domain.model.enums.UserPart
 import com.umc.domain.model.community.CommentItem
 import com.umc.domain.model.community.ContentItem
+import com.umc.domain.model.enums.PermissionType
+import com.umc.domain.model.enums.ResourceType
+import com.umc.domain.usecase.GetAuthAccessUseCase
 import com.umc.domain.usecase.GetChallengerIdUseCase
 import com.umc.domain.usecase.appDataStore.GetUserInfoUseCase
 import com.umc.domain.usecase.community.DeleteCommunityCommentUseCase
@@ -42,8 +45,9 @@ constructor(
     private val deleteCommunityCommentUseCase: DeleteCommunityCommentUseCase, //댓글 삭제하기
     private val updateLikePostUseCase: UpdateLikePostUseCase, //좋아요 토글
     private val updateScrapPostUseCase: UpdateScrapPostUseCase, //스크랩 토글
-    private val getChallengerIdUseCase: GetChallengerIdUseCase, //챌린저 ID 정보 불러오기
     private val reportPostUseCase: ReportPostUseCase, //게시글 신고하기
+    private val getChallengerIdUseCase: GetChallengerIdUseCase, //내 ID 가져오기
+    private val getAuthAccessUseCase: GetAuthAccessUseCase, //리소스 권한 조회
     private val reportCommentUseCase: ReportCommentUseCase, //댓글 신고하기
 
     ) : BaseViewModel<PostDetailFragmentUiState, PostDetailFragmentEvent>(
@@ -93,13 +97,13 @@ constructor(
                 }
             }
 
-            //0. 유저 챌린저 ID 가져오기
+            //0. 유저 challengerId 가져오기
             launch {
-                val myChallengerId = getChallengerIdUseCase()
-                updateState { copy(myChallengerId = myChallengerId) }
+                val challengerId = getChallengerIdUseCase()
+                updateState {
+                    copy(myChallengerId = challengerId)
+                }
             }
-
-
 
             //1. 서로 다른 usecase를 비동기로 실행
             val detailDeferred = async {
@@ -136,9 +140,6 @@ constructor(
                 }
             )
 
-            Log.d("log_community", "게시글 정보: ${fetchedContent}")
-            Log.d("log_community", "유저 정보: ${uiState.value.myInfo}")
-
             //4. 댓글만 받아왔거나 다 실패한 경우 나가기
             if(fetchedContent == null && fetchedComments == null){
                 emitEvent(PostDetailFragmentEvent.ShowErrorToast("게시글을 불러오는데 실패했습니다."))
@@ -147,13 +148,13 @@ constructor(
 
             //5. 둘다 정상이면 한 번에 재조립
             else if (fetchedContent != null && fetchedComments != null) {
-                checkIsAuthor(fetchedContent.userId)
+                checkIsAuthor(fetchedContent.postId)
                 rebuildDetailList(fetchedContent, fetchedComments)
             }
 
             //6. 게시글만 받아왔을 경우 (일단 빌드)
             else if(fetchedContent != null){
-                checkIsAuthor(fetchedContent.userId)
+                checkIsAuthor(fetchedContent.postId)
                 rebuildDetailList(fetchedContent, uiState.value.nowCommentList)
                 emitEvent(PostDetailFragmentEvent.ShowErrorToast("댓글을 불러오는데 실패했습니다."))
             }
@@ -211,18 +212,33 @@ constructor(
     }
 
     //게시글이 현재 유저 것인지 비교
-    fun checkIsAuthor(authorId : Long){
-        val isAuthor = authorId == uiState.value.myChallengerId
+    fun checkIsAuthor(postId : Long){
+        viewModelScope.launch { 
+            resultResponse(
+                response = getAuthAccessUseCase(ResourceType.COMMUNITY_POST, postId),
+                successCallback = { authAccess ->
+                    //삭제 or 수정권한 있는지 체크
+                    val isAuthor = authAccess.permissions.any { item ->
+                        (item.type == PermissionType.DELETE || item.type == PermissionType.EDIT)
+                                && item.hasPermission
+                    }
+                    Log.d("log_community", "권한 결과: $isAuthor")
 
-        updateState {
-            if(isAuthor){
-                copy(isAuthor = true)
-            }
-            else{
-                copy(isAuthor = false)
-            }
+                    updateState {
+                        if(isAuthor){
+                            copy(isAuthor = true)
+                        }
+                        else{
+                            copy(isAuthor = false)
+                        }
+                    }
+            
+                },
+                errorCallback = {
+                    emitEvent(PostDetailFragmentEvent.ShowErrorToast("게시글 권한을 불러오는데 실패했습니다."))
+                }
+            )
         }
-
     }
 
 

--- a/presentation/src/main/java/com/umc/presentation/ui/community/detail/PostDetailViewModel.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/community/detail/PostDetailViewModel.kt
@@ -340,6 +340,29 @@ constructor(
         }
     }
 
+    //댓글 메뉴 바 눌렀을 때, 자신 댓글인지 판단
+    fun onCommentMenuClicked(item: CommentItem) {
+        viewModelScope.launch {
+            resultResponse(
+                // 댓글 권한 조회를 위해 POST_COMMENT 타입 사용 (없다면 Enum에 추가 필요)
+                response = getAuthAccessUseCase(ResourceType.COMMUNITY_COMMENT, item.commentId),
+                successCallback = { authAccess ->
+                    // DELETE 또는 EDIT 권한이 있는지 체크 (팀장님 로직 적용)
+                    val isAuthor = authAccess.permissions.any { p ->
+                        (p.type == PermissionType.DELETE || p.type == PermissionType.EDIT)
+                                && p.hasPermission
+                    }
+
+                    // 권한 결과와 함께 이벤트를 던져 Fragment가 팝업을 띄우게 함
+                    emitEvent(PostDetailFragmentEvent.ShowCommentMenu(item, isAuthor))
+                },
+                errorCallback = {
+                    emitEvent(PostDetailFragmentEvent.ShowErrorToast("권한 정보를 불러오지 못했습니다."))
+                }
+            )
+        }
+    }
+
     //댓글 추가
     fun onClickCommentAdd(){
         emitEvent(PostDetailFragmentEvent.OnClickCommentAdd)
@@ -454,6 +477,9 @@ sealed interface PostDetailFragmentEvent : UiEvent {
 
     //댓글 신고하기 이벤트
     data class ReportComment(val commentId: Long) : PostDetailFragmentEvent
+
+    //댓글 메뉴 누를시 권한 확인 이벤트
+    data class ShowCommentMenu(val item: CommentItem, val canDelete: Boolean) : PostDetailFragmentEvent
 
     //오류 토스트 이벤트
     data class ShowErrorToast(val errorMessage: String) : PostDetailFragmentEvent

--- a/presentation/src/main/java/com/umc/presentation/ui/community/detail/PostDetailViewModel.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/community/detail/PostDetailViewModel.kt
@@ -16,6 +16,8 @@ import com.umc.domain.usecase.community.DeleteCommunityCommentUseCase
 import com.umc.domain.usecase.community.DeleteCommunityPostUseCase
 import com.umc.domain.usecase.community.GetCommunityPostCommentUseCase
 import com.umc.domain.usecase.community.GetCommunityPostDetailUseCase
+import com.umc.domain.usecase.community.ReportCommentUseCase
+import com.umc.domain.usecase.community.ReportPostUseCase
 import com.umc.domain.usecase.community.UpdateLikePostUseCase
 import com.umc.domain.usecase.community.UpdateScrapPostUseCase
 import com.umc.domain.usecase.community.WriteCommunityPostCommentUseCase
@@ -41,6 +43,8 @@ constructor(
     private val updateLikePostUseCase: UpdateLikePostUseCase, //좋아요 토글
     private val updateScrapPostUseCase: UpdateScrapPostUseCase, //스크랩 토글
     private val getChallengerIdUseCase: GetChallengerIdUseCase, //챌린저 ID 정보 불러오기
+    private val reportPostUseCase: ReportPostUseCase, //게시글 신고하기
+    private val reportCommentUseCase: ReportCommentUseCase, //댓글 신고하기
 
     ) : BaseViewModel<PostDetailFragmentUiState, PostDetailFragmentEvent>(
     PostDetailFragmentUiState()
@@ -272,6 +276,38 @@ constructor(
     }
 
 
+    //게시글 신고
+    fun reportPost(){
+        val postId = uiState.value.nowContent.postId
+        viewModelScope.launch {
+            resultResponse(
+                response = reportPostUseCase(postId),
+                successCallback = {
+                    emitEvent(PostDetailFragmentEvent.ShowErrorToast("게시글 신고가 완료되었습니다"))
+                },
+                errorCallback = { error ->
+                    emitEvent(PostDetailFragmentEvent.ShowErrorToast(error.message))
+                }
+            )
+        }
+
+    }
+
+    //댓글 신고
+    fun reportComment(commentId: Long){
+        viewModelScope.launch {
+            resultResponse(
+                response = reportCommentUseCase(commentId),
+                successCallback = {
+                    emitEvent(PostDetailFragmentEvent.ShowErrorToast("댓글 신고가 완료되었습니다"))
+                },
+                errorCallback = { error ->
+                    emitEvent(PostDetailFragmentEvent.ShowErrorToast(error.message))
+                }
+            )
+        }
+    }
+
 
     //게시글 삭제 로직
     fun deletePost(){
@@ -281,7 +317,9 @@ constructor(
                 successCallback = {
                     emitEvent(PostDetailFragmentEvent.MoveBackPressed)
                 },
-                errorCallback = {}
+                errorCallback = {
+                    
+                }
             )
         }
     }
@@ -296,7 +334,7 @@ constructor(
         updateState { copy(isMenuVisible = !isMenuVisible) }
     }
     
-    //게시글 신고
+    //게시글 신고 다이얼로그 열기
     fun onClickReportPost(){
         emitEvent(PostDetailFragmentEvent.ReportPost)
     }
@@ -309,10 +347,7 @@ constructor(
         emitEvent(PostDetailFragmentEvent.DeletePost)
     }
 
-    //댓글 신고
-    fun onClickReportComment(){
-        emitEvent(PostDetailFragmentEvent.ReportComment)
-    }
+
 
     //댓글 삭제
     fun onClickeDeleteComment(item: CommentItem){
@@ -402,7 +437,7 @@ sealed interface PostDetailFragmentEvent : UiEvent {
     object DeletePost : PostDetailFragmentEvent
 
     //댓글 신고하기 이벤트
-    object ReportComment : PostDetailFragmentEvent
+    data class ReportComment(val commentId: Long) : PostDetailFragmentEvent
 
     //오류 토스트 이벤트
     data class ShowErrorToast(val errorMessage: String) : PostDetailFragmentEvent

--- a/presentation/src/main/java/com/umc/presentation/ui/community/detail/PostDetailViewModel.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/community/detail/PostDetailViewModel.kt
@@ -10,6 +10,7 @@ import com.umc.domain.model.enums.RecruitType
 import com.umc.domain.model.enums.UserPart
 import com.umc.domain.model.community.CommentItem
 import com.umc.domain.model.community.ContentItem
+import com.umc.domain.usecase.GetChallengerIdUseCase
 import com.umc.domain.usecase.appDataStore.GetUserInfoUseCase
 import com.umc.domain.usecase.community.DeleteCommunityCommentUseCase
 import com.umc.domain.usecase.community.DeleteCommunityPostUseCase
@@ -39,6 +40,7 @@ constructor(
     private val deleteCommunityCommentUseCase: DeleteCommunityCommentUseCase, //댓글 삭제하기
     private val updateLikePostUseCase: UpdateLikePostUseCase, //좋아요 토글
     private val updateScrapPostUseCase: UpdateScrapPostUseCase, //스크랩 토글
+    private val getChallengerIdUseCase: GetChallengerIdUseCase, //챌린저 ID 정보 불러오기
 
     ) : BaseViewModel<PostDetailFragmentUiState, PostDetailFragmentEvent>(
     PostDetailFragmentUiState()
@@ -83,12 +85,17 @@ constructor(
             //0. 유저 정보 가져오기 (별도 분리)
             launch {
                 getUserInfoUseCase().collect { userInfo ->
-                    updateState { copy(
-                        myInfo = userInfo,
-                        myId = userInfo.id
-                    ) }
+                    updateState { copy(myInfo = userInfo) }
                 }
             }
+
+            //0. 유저 챌린저 ID 가져오기
+            launch {
+                val myChallengerId = getChallengerIdUseCase()
+                updateState { copy(myChallengerId = myChallengerId) }
+            }
+
+
 
             //1. 서로 다른 usecase를 비동기로 실행
             val detailDeferred = async {
@@ -158,7 +165,7 @@ constructor(
 
         viewModelScope.launch {
             val postId = uiState.value.nowContent.postId
-            val myId = uiState.value.myId
+            val myId = uiState.value.myChallengerId
 
             resultResponse(
                 response = writeCommunityPostCommentUseCase(postId, myId, text),
@@ -201,7 +208,7 @@ constructor(
 
     //게시글이 현재 유저 것인지 비교
     fun checkIsAuthor(authorId : Long){
-        val isAuthor = authorId == uiState.value.myId
+        val isAuthor = authorId == uiState.value.myChallengerId
 
         updateState {
             if(isAuthor){
@@ -350,7 +357,7 @@ data class PostDetailFragmentUiState(
     //내 ID
     /**TODO. 얘는 MemberId인지 ChallengerId인지 확인 필요**/
     val myInfo : UserInfo? = null,
-    val myId : Long = -1L,
+    val myChallengerId : Long = -1L,
 
     //현재 게시글
     val nowContent: ContentItem = ContentItem(

--- a/presentation/src/main/java/com/umc/presentation/ui/home/PlanAddViewModel.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/home/PlanAddViewModel.kt
@@ -8,6 +8,7 @@ import com.umc.domain.model.enums.UserPart
 import com.umc.domain.model.home.CategoryItem
 import com.umc.domain.model.home.LocationItem
 import com.umc.domain.model.home.ParticipantItem
+import com.umc.domain.model.home.getGisuSummaryList
 import com.umc.domain.model.home.schedule.CreateSchedule
 import com.umc.domain.model.home.schedule.UpdateSchedule
 import com.umc.domain.usecase.appDataStore.GetUserInfoUseCase
@@ -33,9 +34,6 @@ import javax.inject.Inject
 @HiltViewModel
 class PlanAddViewModel @Inject
 constructor(
-    private val getRecentSearchPlaceUseCase: GetRecentSearchPlaceUseCase, //최근 장소 기록 불러오기;
-    private val updateRecentSearchPlaceUseCase: UpdateRecentSearchPlaceUseCase, //최근 장소 기록 업데이트하기
-    private val getSearchLocationUseCase: GetSearchLocationUseCase, //카카오 SDK로 장소 검색하기
     private val getUserInfoUseCase: GetUserInfoUseCase, //유저 정보 가져오기
     private val getScheduleDetailHomeUseCase: GetScheduleDetailHomeUseCase, //일정 상세 정보 가져오기,
     private val createScheduleUseCase: CreateScheduleUseCase, //일정 생성하기
@@ -62,7 +60,18 @@ constructor(
             //유저 정보 가져오기
             launch {
                 getUserInfoUseCase().collect { userInfo ->
-                    updateState { copy(myInfo = userInfo) }
+
+                    //기수 요약 리스트 작성
+                    val gisuSummaryList = userInfo.getGisuSummaryList()
+                    val latestGisu = gisuSummaryList.maxByOrNull { it.gisu }
+                    //최신 기수ID 얻기
+                    val latestGisuId = latestGisu?.gisuId ?: 1L
+
+                    updateState {
+                        copy(
+                            myInfo = userInfo,
+                            nowGisuId = latestGisuId
+                            ) }
                 }
             }
         }
@@ -225,7 +234,7 @@ constructor(
                     description = state.planDetail,
                     tags = selectedTags,
                     participantMemberIds = participantIds,
-                    gisuId = 1L,
+                    gisuId = state.nowGisuId,
                     requiresApproval = state.isManager
                 )
 
@@ -338,12 +347,15 @@ data class PlanAddFragmentUiState(
     //챌린저 내 정보
     val myInfo : UserInfo = UserInfo(),
 
+    //내 최신 기수
+    val nowGisuId: Long = -1L,
+
     ////스케쥴 수정용 id
     val updateScheduleId : Long = -1L,
 
 
     //운영진 여부 판단
-    val isManager: Boolean = false,
+    val isManager: Boolean = true,
 
     //하루 종일 부분에 체크가 되었나
     val isAllDay: Boolean = false,

--- a/presentation/src/main/java/com/umc/presentation/ui/home/PlanAddViewModel.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/home/PlanAddViewModel.kt
@@ -102,6 +102,9 @@ constructor(
                             selectedOnes.size <= 3 -> selectedOnes.joinToString(", ") { it.name }
                             else -> "${selectedOnes.take(3).joinToString(", ") { it.name }} 외 ${selectedOnes.size - 3}개"
                         }
+
+                        //4. 참석자 매칭
+
                         
                         //4. 갱신 저장
                         copy(
@@ -121,7 +124,7 @@ constructor(
                             startTimeText = startTimeTextFormatted,
                             endDateText = detail.endDay,
                             endTimeText = endTimeTextFormatted,
-                            selectedCategoriesString = summaryText
+                            selectedCategoriesString = summaryText,
                         )
                     }
                 },

--- a/presentation/src/main/java/com/umc/presentation/ui/home/PlanDetailFragment.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/home/PlanDetailFragment.kt
@@ -183,6 +183,8 @@ class PlanDetailFragment : BaseFragment<FragmentPlanDetailBinding, PlanDetailFra
     //해당 탭을 닫고 이동하는 로직
     /**TODO 로직 작성 필요**/
     private fun clickConfirmAttention(){
+        val action = PlanDetailFragmentDirections.actionPlanDetailToNavAct()
+        findNavController().navigate(action)
 
     }
 

--- a/presentation/src/main/java/com/umc/presentation/ui/home/PlanDetailViewModel.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/home/PlanDetailViewModel.kt
@@ -2,7 +2,10 @@ package com.umc.presentation.ui.home
 
 import android.util.Log
 import androidx.lifecycle.viewModelScope
+import com.umc.domain.model.enums.PermissionType
+import com.umc.domain.model.enums.ResourceType
 import com.umc.domain.model.home.PlanDetailItem
+import com.umc.domain.usecase.GetAuthAccessUseCase
 import com.umc.domain.usecase.schedule.DeleteScheduleUseCase
 import com.umc.domain.usecase.schedule.GetScheduleDetailHomeUseCase
 import com.umc.presentation.base.BaseViewModel
@@ -20,6 +23,7 @@ class PlanDetailViewModel @Inject
 constructor(
     private val getScheduleDetailHomeUseCase: GetScheduleDetailHomeUseCase, //일정 상세 정보 가져오기
     private val deleteScheduleUseCase: DeleteScheduleUseCase, //일정 삭제하기
+    private val getAuthAccessUseCase: GetAuthAccessUseCase, //리소스 권한 조회
     ) : BaseViewModel<PlanDetailFragmentUiState, PlanDetailFragmentEvent>(
     PlanDetailFragmentUiState()){
 
@@ -36,6 +40,7 @@ constructor(
                             content = it,
                             plusDay = plusDay)
                         }
+                        settingScheduleAuthAceess(it.scheduleId)
 
                         convertPlanDetailItemToUiState(it, plusDay)
                     },
@@ -43,6 +48,29 @@ constructor(
 
                     }
                 )
+            }
+        }
+
+        //일정 게시글 접근 권한 조회 및 UI 설정 함수
+        fun settingScheduleAuthAceess(scheduleId : Long){
+            viewModelScope.launch {
+                resultResponse(
+                    response = getAuthAccessUseCase(ResourceType.SCHEDULE, scheduleId),
+                    successCallback = { authAccess ->
+                        //삭제나 작성 권한이 있으면 isAuthor로 취급
+                        val isAuthor = authAccess.permissions.any { item ->
+                            (item.type == PermissionType.DELETE || item.type == PermissionType.WRITE)
+                                    && item.hasPermission
+                        }
+
+                        updateState {
+                            copy(isAuthor = isAuthor)
+                        }
+
+                    },
+                    errorCallback = {},
+                )
+
             }
         }
 
@@ -99,6 +127,7 @@ constructor(
 
         }
 
+        //일정 계산하는 포맷 함수
         private fun calculateTargetDate(startDay: String, plusDay: Int): String {
             return try {
                 val formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd")
@@ -183,7 +212,7 @@ data class PlanDetailFragmentUiState(
 
 
     //내가 작성한 것인지 여부
-    val isAuthor: Boolean = true,
+    val isAuthor: Boolean = false,
 
     //케밥 메뉴 아이콘 보이기 여부
     val isMenuVisible : Boolean = false,

--- a/presentation/src/main/java/com/umc/presentation/ui/home/PlanDetailViewModel.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/home/PlanDetailViewModel.kt
@@ -40,7 +40,7 @@ constructor(
                             content = it,
                             plusDay = plusDay)
                         }
-                        settingScheduleAuthAceess(it.scheduleId)
+                        settingScheduleAuthAccess(it.scheduleId)
 
                         convertPlanDetailItemToUiState(it, plusDay)
                     },
@@ -52,7 +52,7 @@ constructor(
         }
 
         //일정 게시글 접근 권한 조회 및 UI 설정 함수
-        fun settingScheduleAuthAceess(scheduleId : Long){
+        fun settingScheduleAuthAccess(scheduleId : Long){
             viewModelScope.launch {
                 resultResponse(
                     response = getAuthAccessUseCase(ResourceType.SCHEDULE, scheduleId),

--- a/presentation/src/main/java/com/umc/presentation/ui/home/PlanDetailViewModel.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/home/PlanDetailViewModel.kt
@@ -59,7 +59,7 @@ constructor(
                     successCallback = { authAccess ->
                         //삭제나 작성 권한이 있으면 isAuthor로 취급
                         val isAuthor = authAccess.permissions.any { item ->
-                            (item.type == PermissionType.DELETE || item.type == PermissionType.WRITE)
+                            (item.type == PermissionType.DELETE || item.type == PermissionType.EDIT)
                                     && item.hasPermission
                         }
 

--- a/presentation/src/main/java/com/umc/presentation/ui/home/dialog/BottomSheetParticipantDialog.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/home/dialog/BottomSheetParticipantDialog.kt
@@ -35,7 +35,7 @@ class BottomSheetParticipantDialog(
     private var _binding: LayoutBottomSheetParticipantAddBinding? = null
     private val binding get() = _binding!!
 
-    private val viewModel: BottomSheetParticipantViewModel by viewModels()
+    private val viewModel: BottomSheetParticipantViewModel by viewModels({ requireParentFragment() })
     private lateinit var addAdapter: BottomSheetAddParticipantAdapter
     private lateinit var searchAdapter: BottomSheetSearchParticipantAdapter
 

--- a/presentation/src/main/java/com/umc/presentation/ui/mypage/MypageFragment.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/mypage/MypageFragment.kt
@@ -168,8 +168,8 @@ class MypageFragment : BaseFragment<FragmentMypageBinding, MypageFragmentUiState
             is MypageFragmentEvent.Logout -> {
                 //1. 다이얼로그로 체크
                 val dialog = UMypageDialog(logoutDialogModel) {
-
                     viewModel.deleteAllData()
+
                     val action = MainGraphDirections.actionGlobalToLogin()
                     findNavController().navigate(action)
 
@@ -182,7 +182,7 @@ class MypageFragment : BaseFragment<FragmentMypageBinding, MypageFragmentUiState
             is MypageFragmentEvent.DeleteUser -> {
                 //1. 다이얼로그로 체크
                 val dialog = UMypageDialog(deleteUserDialogModel) {
-                    /**TODO 회원 탈퇴 로직 생성**/
+                    viewModel.deleteUser()
 
                 }
 
@@ -198,7 +198,11 @@ class MypageFragment : BaseFragment<FragmentMypageBinding, MypageFragmentUiState
             is MypageFragmentEvent.NavigateToInstagramUmc -> {
                 openWebpage(viewModel.uiState.value.instagramUMC)
             }
-            
+
+            is MypageFragmentEvent.MoveToOnBoardPage -> {
+                val action = MainGraphDirections.actionGlobalToLogin()
+                findNavController().navigate(action)
+            }
             
 
             else -> {}

--- a/presentation/src/main/java/com/umc/presentation/ui/mypage/MypageViewModel.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/mypage/MypageViewModel.kt
@@ -200,8 +200,19 @@ class MypageViewModel @Inject constructor(
         emitEvent(MypageFragmentEvent.NavigateToInstagramUmc)
     }
 
+    fun navigateToOnBoardPage(){
+        emitEvent(MypageFragmentEvent.MoveToOnBoardPage)
+    }
 
 
+
+    //유저 삭제 다이얼로그 호출
+    fun showDeleteUserDialog(){
+        //1. 삭제 이벤트를 전송
+        emitEvent(MypageFragmentEvent.DeleteUser)
+    }
+
+    //2. 유저 삭제 로직(여기서 실징 수행)
     fun deleteUser(){
         viewModelScope.launch {
             resultResponse(
@@ -210,7 +221,7 @@ class MypageViewModel @Inject constructor(
                     viewModelScope.launch {
                         // 회원 탈퇴 성공 시 dataStore의 모든 데이터 삭제
                         clearAllDataUseCase()
-                        emitEvent(MypageFragmentEvent.DeleteUser)
+                        emitEvent(MypageFragmentEvent.MoveToOnBoardPage)
                     }
                 },
                 errorCallback = {
@@ -219,6 +230,8 @@ class MypageViewModel @Inject constructor(
             )
         }
     }
+
+
 
     fun logout(){
         emitEvent(MypageFragmentEvent.Logout)
@@ -285,5 +298,9 @@ sealed interface MypageFragmentEvent : UiEvent {
 
     //회원 탈퇴
     object DeleteUser : MypageFragmentEvent
+
+    //처음으로 이동
+    object MoveToOnBoardPage : MypageFragmentEvent
+
 
 }

--- a/presentation/src/main/java/com/umc/presentation/ui/mypage/profile/ProfileViewModel.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/mypage/profile/ProfileViewModel.kt
@@ -76,6 +76,7 @@ class ProfileViewModel @Inject constructor(
             //2. 운영진 기록이 있으면 싹다 만들기
             summary.fromRoles.forEach { roleItem ->
                     //담당 파트가 있으면 (웹 파트장)
+                Log.d("log_mypage", "운영 IN: ${roleItem}")
                     val item = if (roleItem.responsiblePart != null) {
                         UserActiveItem(
                             generation = generationText,
@@ -94,16 +95,19 @@ class ProfileViewModel @Inject constructor(
                             position = roleLabel
                         )
                     }
+                    Log.d("log_mypage", "결과: ${item}")
                     activeHistory.add(item)
                 }
 
             //3. 챌린저 기록이 있으면 싹 다 만들기
             summary.fromRecords.forEach { recordItem ->
+                Log.d("log_mypage", "챌린저: ${recordItem}")
                 val item = UserActiveItem(
                     generation = generationText,
                     partName = "${recordItem.responsiblePart} Part",
                     position = "챌린저"
                 )
+                Log.d("log_mypage", "결과: ${item}")
                 activeHistory.add(item)
             }
         }

--- a/presentation/src/main/java/com/umc/presentation/ui/mypage/profile/ProfileViewModel.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/mypage/profile/ProfileViewModel.kt
@@ -6,6 +6,8 @@ import androidx.lifecycle.viewModelScope
 import com.umc.domain.model.UserInfo
 import com.umc.domain.model.enums.LoginType
 import com.umc.domain.model.enums.UploadFileCategory
+import com.umc.domain.model.enums.UserChallengerRole
+import com.umc.domain.model.home.getGisuSummaryList
 import com.umc.domain.model.mypage.UserActiveItem
 import com.umc.domain.model.mypage.UserOutLink
 import com.umc.domain.repository.AppDataStoreRepository
@@ -53,9 +55,73 @@ class ProfileViewModel @Inject constructor(
                         userInfo = userInfo,
                     )
                 }
-                Log.d("log_mypage", "dataSource 정보 : $userInfo")
+                settingUserInfoToUI(userInfo)
             }
         }
+
+    }
+
+    //유저 정보를 통해 활동 이력 및 기수파트 작성
+    fun settingUserInfoToUI(userInfo: UserInfo){
+        val gisuSummaryList = userInfo.getGisuSummaryList()
+
+        //최종 리스트
+        val activeHistory = mutableListOf<UserActiveItem>()
+
+        //gisuSummaryList를 돌면서 만들기
+        gisuSummaryList.forEach { summary->
+            //1. 기수 별 분류 (여기에 roles/ challengers)
+            val generationText = "${summary.gisu}기"
+
+            //2. 운영진 기록이 있으면 싹다 만들기
+            summary.fromRoles.forEach { roleItem ->
+                    //담당 파트가 있으면 (웹 파트장)
+                    val item = if (roleItem.responsiblePart != null) {
+                        UserActiveItem(
+                            generation = generationText,
+                            partName = "${roleItem.responsiblePart} Part",
+                            position = roleItem.role
+                        )
+                    }
+                    //담당 파트가 없으면 (총괄)
+                    else {
+                        val roleLabel =
+                            //label 없으면 enum 이름 그대로 쓰자.
+                            UserChallengerRole.from(roleItem.role).displayName ?: roleItem.role
+                        UserActiveItem(
+                            generation = generationText,
+                            partName = roleLabel,
+                            position = roleLabel
+                        )
+                    }
+                    activeHistory.add(item)
+                }
+
+            //3. 챌린저 기록이 있으면 싹 다 만들기
+            summary.fromRecords.forEach { recordItem ->
+                val item = UserActiveItem(
+                    generation = generationText,
+                    partName = "${recordItem.responsiblePart} Part",
+                    position = "챌린저"
+                )
+                activeHistory.add(item)
+            }
+        }
+
+        //최신 파트(기수/파트) - 이거는 role 우선
+        val latestHistory = activeHistory.firstOrNull()
+        val latestPartAndGisu = latestHistory?.let {
+            "${it.generation}/${it.partName.replace(" Part", "")}"
+        } ?: "정보 없음"
+
+        //이 정보를 저장
+        updateState {
+            copy(
+                myActiveHistory = activeHistory,
+                myPart = latestPartAndGisu
+            )
+        }
+
 
     }
 
@@ -150,7 +216,7 @@ class ProfileViewModel @Inject constructor(
 data class ProfileFragmentUiState(
     //유저 정보 (고정)
     val loginType: LoginType = LoginType.KAKAO,
-    val myPart: String = "9기/Android",
+    val myPart: String = "",
     val userInfo : UserInfo = UserInfo(),
 
 
@@ -163,20 +229,7 @@ data class ProfileFragmentUiState(
 
 
     //임시 정보
-    val myActiveHistory: List<UserActiveItem> = listOf(
-        UserActiveItem(
-            generation = "8기",
-            partName = "Android Part",
-            position = "챌린저"),
-        UserActiveItem(
-            generation = "9기",
-            partName = "Android Part",
-            position = "파트장"),
-        UserActiveItem(
-            generation = "9기",
-            partName = "Android Part",
-            position = "파트장"),
-    ),
+    val myActiveHistory: List<UserActiveItem> = emptyList(),
 
     ) : UiState
 

--- a/presentation/src/main/java/com/umc/presentation/ui/mypage/profile/ProfileViewModel.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/mypage/profile/ProfileViewModel.kt
@@ -76,7 +76,6 @@ class ProfileViewModel @Inject constructor(
             //2. 운영진 기록이 있으면 싹다 만들기
             summary.fromRoles.forEach { roleItem ->
                     //담당 파트가 있으면 (웹 파트장)
-                Log.d("log_mypage", "운영 IN: ${roleItem}")
                     val item = if (roleItem.responsiblePart != null) {
                         UserActiveItem(
                             generation = generationText,
@@ -95,19 +94,17 @@ class ProfileViewModel @Inject constructor(
                             position = roleLabel
                         )
                     }
-                    Log.d("log_mypage", "결과: ${item}")
+
                     activeHistory.add(item)
                 }
 
             //3. 챌린저 기록이 있으면 싹 다 만들기
             summary.fromRecords.forEach { recordItem ->
-                Log.d("log_mypage", "챌린저: ${recordItem}")
                 val item = UserActiveItem(
                     generation = generationText,
                     partName = "${recordItem.responsiblePart} Part",
                     position = "챌린저"
                 )
-                Log.d("log_mypage", "결과: ${item}")
                 activeHistory.add(item)
             }
         }

--- a/presentation/src/main/res/layout/fragment_mypage.xml
+++ b/presentation/src/main/res/layout/fragment_mypage.xml
@@ -1078,7 +1078,7 @@
             android:id="@+id/mypage_btn_delete_user"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:onClick="@{()->vm.deleteUser()}"
+            android:onClick="@{()->vm.showDeleteUserDialog()}"
             android:layout_marginTop="32dp"
             android:layout_marginEnd="6dp"
             app:contentPadding="16dp"

--- a/presentation/src/main/res/navigation/nav_home.xml
+++ b/presentation/src/main/res/navigation/nav_home.xml
@@ -6,6 +6,8 @@
     app:startDestination="@id/homeFragment"
     >
 
+    <include app:graph="@navigation/nav_act" />
+
     <fragment
         android:id="@+id/homeFragment"
         android:name="com.umc.presentation.ui.home.HomeFragment"
@@ -48,6 +50,17 @@
             android:id="@+id/action_planDetail_to_planAdd"
             app:destination="@id/planAddFragment"/>
 
+        <action
+            android:id="@+id/action_planDetail_to_nav_act"
+            app:destination="@id/nav_act"
+            app:popUpTo="@id/nav_home"
+            app:popUpToInclusive="true"
+            app:launchSingleTop="true"
+            >
+
+
+        </action>
+
         <argument
             android:name="scheduleId"
             app:argType="long"
@@ -71,6 +84,7 @@
             android:name="scheduleId"
             app:argType="long"
             android:defaultValue="-1L" />
+
 
     </fragment>
 


### PR DESCRIPTION
## #️⃣ 이슈 번호

> 관련된 이슈 번호를 적어주세요.\
> Close #101

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 요약해주세요.

1. 리소스 접근 권한 API를 연결하고, 이를 이용해 일정 수정/삭제 권한 판단에 따라 (삭제/수정, 신고) 다이얼로그 로직 분리

2. 게시글/댓글 신고 API 연결 및 usecase 연결 (현재 서버 문제로 테스트 불가)

3. UserInfo를 파싱하여, 최신기수 challengerId를 파싱하는 useCase 생성
   - 이를 이용하여, 게시글/댓글이 자신것인지를 판단하여, (삭제/수정, 신고) 다이얼로그 로직 분리

4. 최신 기수 id를 반환하는 로직 생성 - 일정 생성 API 마무리

5. UserInfo를 파싱하여, 유저의 활동내역(직함 리스트)을 출력하는 기능 추가 및 프로필 페이지 반영
  - UserChallengerRole enum에 기타 직함 displayName 추가 필요
 

**추가**
6. 게시글 출석 시 활동 탭으로 이동하는 로직 추가
7. 유저 선택 다이얼로그 생명주기 오류 수정(다이얼로그가 닫혀도 선택한 인원 유지)
8. 게시글 신고 방법 변경 : ChallengerId 기반 -> 리소스 권한 조회


## 📸 스크린샷 (선택 사항)
| 프로필 활동내역 추가 | 이미지 |
| :---: | :---: |
| ![KakaoTalk_20260217_223905148](https://github.com/user-attachments/assets/7cf9134c-2e83-4da1-8451-6bcd17fc273b) |  |

## 🚩 리뷰 요구사항
> 리뷰어가 중점적으로 봐주었으면 하는 부분이 있다면 작성해주세요.

리소스 접근 권한 API의 경우, 일정 외에도 공지나 워크북 세션에 사용되는 것을 확인했습니다.

이에 이를 사용하는 usecase를 별도의 패키지 없이 usecase 패키지 하단에 바로 `GetAuthAccessUseCase`를 정의했습니다. (response 타입은 서버에서 받아온 내용 그대로 받아와 `AuthAccess` class 에 정의했습니다.)

또한, 리소스 타입 및 권한(CRUD) 타입을 enum class로 `ResourceType`, `PermissionType`으로 정의했으니, 추후 사용 시 참고 바랍니다.



## 🏁 체크리스트
- [ ] 코딩 컨벤션을 준수했나요?
- [ ] 불필요한 로그나 주석을 제거했나요?
- [ ] 머지 대상 브랜치(Base branch)가 올바른가요?
