### PR TITLE
[Feat/#122] 명예의 전당 구현 및 UI 수정

### DIFF
--- a/app/src/main/java/com/umc/product/di/AuthenticationInterceptor.kt
+++ b/app/src/main/java/com/umc/product/di/AuthenticationInterceptor.kt
@@ -30,7 +30,7 @@ class AuthenticationInterceptor @Inject constructor(
 
             val request =
                 chain.request().newBuilder()
-                    .addHeader("Authorization", "Bearer ${testToken}").build()
+                    .addHeader("Authorization", "Bearer ${accessToken}").build()
 
             Log.d(
                 "RETROFIT",

--- a/app/src/main/java/com/umc/product/di/AuthenticationInterceptor.kt
+++ b/app/src/main/java/com/umc/product/di/AuthenticationInterceptor.kt
@@ -25,8 +25,8 @@ class AuthenticationInterceptor @Inject constructor(
             }
 
             val accessToken = runBlocking { appDataStoreRepository.getAccessToken() }
-            val testToken = "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNzcxODIxMTU0LCJleHAiOjE3NzE4MzU1NTR9.HQQo" +
-                    "xA0JxmHnH3OY4b8F3XvwX2kVzdI4iUC9Qx5Wm0MJC3J-PLOsihT_CCX2w-pqn_GlUPpz2Nc1LvfQd1Pb1w"
+            val testToken = "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNzcxODM2ODQ2LCJleHAiOj" +
+                    "E3NzE4NjU2NDZ9.d3KwwUTPcyeJhWw2Qp6uS4O10ID3LG6H4GxdCDbNszGKLtCylSqXoFd_vRDN-L1GKFmUfdJCLPsrvSQN1Z-8AA"
 
             val request =
                 chain.request().newBuilder()

--- a/app/src/main/java/com/umc/product/di/AuthenticationInterceptor.kt
+++ b/app/src/main/java/com/umc/product/di/AuthenticationInterceptor.kt
@@ -25,12 +25,12 @@ class AuthenticationInterceptor @Inject constructor(
             }
 
             val accessToken = runBlocking { appDataStoreRepository.getAccessToken() }
-            val testToken = "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNzcxMzMzMTA" +
-                    "xLCJleHAiOjE3NzEzMzY3MDF9.aECNrnOmnYKSjqusLf5SsvwSDcmQQpoMduJhgQvz_LPAaEYyURZDB6thB90LSliWlf0ZM_rsWCTyUJNEpe_F-w"
+            val testToken = "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNzcxODIxMTU0LCJleHAiOjE3NzE4MzU1NTR9.HQQo" +
+                    "xA0JxmHnH3OY4b8F3XvwX2kVzdI4iUC9Qx5Wm0MJC3J-PLOsihT_CCX2w-pqn_GlUPpz2Nc1LvfQd1Pb1w"
 
             val request =
                 chain.request().newBuilder()
-                    .addHeader("Authorization", "Bearer ${accessToken}").build()
+                    .addHeader("Authorization", "Bearer ${testToken}").build()
 
             Log.d(
                 "RETROFIT",

--- a/data/src/main/java/com/umc/data/api/CommunityApi.kt
+++ b/data/src/main/java/com/umc/data/api/CommunityApi.kt
@@ -3,12 +3,14 @@ package com.umc.data.api
 import com.umc.data.request.community.CreateCommentRequest
 import com.umc.data.request.community.CreatePostLightningRequest
 import com.umc.data.request.community.CreatePostRequest
+import com.umc.data.request.community.CreateTrophyRequest
 import com.umc.data.response.community.CommunityGetPostResponse
 import com.umc.data.response.community.CommunitySearchPostResponse
 import com.umc.data.response.community.PostCommentResponse
 import com.umc.data.response.community.PostDetailResponse
 import com.umc.data.response.community.PostLikeResponse
 import com.umc.data.response.community.PostScrapResponse
+import com.umc.data.response.community.TrophyResponse
 import com.umc.domain.model.base.ApiResponse
 import retrofit2.http.Body
 import retrofit2.http.DELETE
@@ -149,5 +151,18 @@ interface CommunityApi {
         @Path("commentId") commentId: Long
     ): ApiResponse<Unit>
 
+    //명예의 전당 게시글 생성
+    @POST(Endpoints.Community.TROPHY)
+    suspend fun createTrophy(
+        @Body request: CreateTrophyRequest
+    ): ApiResponse<TrophyResponse>
+
+    //명예의 전당게시글 조회
+    @GET(Endpoints.Community.TROPHY)
+    suspend fun getTrophies(
+        @Query("week") week: Int?,
+        @Query("school") school: String?,
+        @Query("part") part: String?,
+    ): ApiResponse<List<TrophyResponse>>
 
 }

--- a/data/src/main/java/com/umc/data/api/Endpoints.kt
+++ b/data/src/main/java/com/umc/data/api/Endpoints.kt
@@ -85,12 +85,10 @@ object Endpoints {
         const val MY_SCRAP = "$COMMUNITY/scrapped"
 
         const val MODIFY_LIGHTNING = "$COMMUNITY/{postId}/lightning"
-
         const val REPORT_POST = "$COMMUNITY/{postId}/reports"
-
         const val REPORT_COMMENT = "api/v1/comments/{commentId}/reports"
 
-
+        const val TROPHY = "api/v1/trophies"
 
 
     }

--- a/data/src/main/java/com/umc/data/dataSource/remote/community/CommunityRemoteDataSource.kt
+++ b/data/src/main/java/com/umc/data/dataSource/remote/community/CommunityRemoteDataSource.kt
@@ -3,12 +3,14 @@ package com.umc.data.dataSource.remote.community
 import com.umc.data.request.community.CreateCommentRequest
 import com.umc.data.request.community.CreatePostLightningRequest
 import com.umc.data.request.community.CreatePostRequest
+import com.umc.data.request.community.CreateTrophyRequest
 import com.umc.data.response.community.CommunityGetPostResponse
 import com.umc.data.response.community.CommunitySearchPostResponse
 import com.umc.data.response.community.PostCommentResponse
 import com.umc.data.response.community.PostDetailResponse
 import com.umc.data.response.community.PostLikeResponse
 import com.umc.data.response.community.PostScrapResponse
+import com.umc.data.response.community.TrophyResponse
 import com.umc.domain.model.base.ApiResponse
 import com.umc.domain.model.base.ApiState
 
@@ -67,4 +69,10 @@ interface CommunityRemoteDataSource {
 
     //댓글 신고
     suspend fun reportComment(commentId: Long): ApiState<Unit>
+
+    //명예의 전당 게시글 생성
+    suspend fun createTrophy(request: CreateTrophyRequest): ApiState<TrophyResponse>
+
+    //명예의 전당 게시글
+    suspend fun getTrophies(week: Int?, school: String?, part: String?): ApiState<List<TrophyResponse>>
 }

--- a/data/src/main/java/com/umc/data/dataSource/remote/community/CommunityRemoteDataSourceImpl.kt
+++ b/data/src/main/java/com/umc/data/dataSource/remote/community/CommunityRemoteDataSourceImpl.kt
@@ -5,12 +5,14 @@ import com.umc.data.dataSource.base.apiCall
 import com.umc.data.request.community.CreateCommentRequest
 import com.umc.data.request.community.CreatePostLightningRequest
 import com.umc.data.request.community.CreatePostRequest
+import com.umc.data.request.community.CreateTrophyRequest
 import com.umc.data.response.community.CommunityGetPostResponse
 import com.umc.data.response.community.CommunitySearchPostResponse
 import com.umc.data.response.community.PostCommentResponse
 import com.umc.data.response.community.PostDetailResponse
 import com.umc.data.response.community.PostLikeResponse
 import com.umc.data.response.community.PostScrapResponse
+import com.umc.data.response.community.TrophyResponse
 import com.umc.domain.model.base.ApiResponse
 import com.umc.domain.model.base.ApiState
 import javax.inject.Inject
@@ -127,6 +129,20 @@ class CommunityRemoteDataSourceImpl @Inject constructor(
     //댓글 신고
     override suspend fun reportComment(commentId: Long): ApiState<Unit> {
         return apiCall { communityApi.reportComment(commentId) }
+    }
+
+    //명예의 전당 가져오기
+    override suspend fun getTrophies(
+        week: Int?,
+        school: String?,
+        part: String?
+    ): ApiState<List<TrophyResponse>> {
+        return apiCall { communityApi.getTrophies(week, school, part) }
+    }
+
+    //명예의 전당 게시글 작성
+    override suspend fun createTrophy(request: CreateTrophyRequest): ApiState<TrophyResponse> {
+        return apiCall { communityApi.createTrophy(request) }
     }
 
 }

--- a/data/src/main/java/com/umc/data/repository/community/CommunityRepositoryImpl.kt
+++ b/data/src/main/java/com/umc/data/repository/community/CommunityRepositoryImpl.kt
@@ -4,12 +4,14 @@ import com.umc.data.dataSource.remote.community.CommunityRemoteDataSource
 import com.umc.data.request.community.CreateCommentRequest
 import com.umc.data.request.community.CreatePostLightningRequest
 import com.umc.data.request.community.CreatePostRequest
+import com.umc.data.request.community.CreateTrophyRequest
 import com.umc.data.response.community.CommunityGetPostResponse.Companion.toPostPageModelDomain
 import com.umc.data.response.community.CommunitySearchPostResponse.Companion.toPostPageModelDomain
 import com.umc.data.response.community.PostCommentResponse.Companion.toCommentItemDomain
 import com.umc.data.response.community.PostDetailResponse.Companion.toContentItemDomain
 import com.umc.data.response.community.PostLikeResponse.Companion.toPostLikeDomain
 import com.umc.data.response.community.PostScrapResponse.Companion.toPostScrapDomain
+import com.umc.data.response.community.TrophyResponse.Companion.toTrophyBody
 import com.umc.domain.model.base.ApiState
 import com.umc.domain.model.base.map
 import com.umc.domain.model.community.CommentItem
@@ -19,6 +21,8 @@ import com.umc.domain.model.community.CreatePost
 import com.umc.domain.model.community.PostLike
 import com.umc.domain.model.community.PostPageModel
 import com.umc.domain.model.community.PostScrap
+import com.umc.domain.model.community.TrophyBody
+import com.umc.domain.model.community.TrophyWrite
 import com.umc.domain.repository.community.CommunityRepository
 import javax.inject.Inject
 
@@ -152,5 +156,30 @@ class CommunityRepositoryImpl @Inject constructor(
     override suspend fun reportComment(commentId: Long): ApiState<Unit> {
         return communityRemoteDataSource.reportComment(commentId)
     }
+
+    //명예의전당 불러오기
+    override suspend fun getTrophies(week: Int?, school: String?, part: String?
+    ): ApiState<List<TrophyBody>> {
+        return communityRemoteDataSource.getTrophies(week, school, part).map {
+            it.map {
+                it.toTrophyBody()
+            }
+        }
+    }
+
+    override suspend fun createTrophy(request: TrophyWrite): ApiState<TrophyBody> {
+        val request = CreateTrophyRequest(
+            challengerId = request.challengerId,
+            title = request.title,
+            content = request.content,
+            url = request.url,
+            week = request.week
+        )
+        return communityRemoteDataSource.createTrophy(request).map {
+            it.toTrophyBody()
+        }
+
+    }
+
 
 }

--- a/data/src/main/java/com/umc/data/request/community/CreateTrophyRequest.kt
+++ b/data/src/main/java/com/umc/data/request/community/CreateTrophyRequest.kt
@@ -1,0 +1,11 @@
+package com.umc.data.request.community
+
+import com.google.gson.annotations.SerializedName
+
+data class CreateTrophyRequest(
+    @SerializedName("challengerId") val challengerId: Long,
+    @SerializedName("week") val week: Int,
+    @SerializedName("title") val title: String,
+    @SerializedName("content") val content: String,
+    @SerializedName("url") val url: String
+)

--- a/data/src/main/java/com/umc/data/response/community/TrophyResponse.kt
+++ b/data/src/main/java/com/umc/data/response/community/TrophyResponse.kt
@@ -1,0 +1,43 @@
+package com.umc.data.response.community
+
+import com.google.gson.annotations.SerializedName
+import com.umc.domain.model.community.TrophyBody
+import com.umc.domain.model.enums.UserPart
+
+data class TrophyResponse(
+    @SerializedName("trophyId") val trophyId: Long,
+    @SerializedName("challengerId") val challengerId: Long,
+    @SerializedName("week") val week: String,
+    @SerializedName("challengerName") val challengerName: String,
+    @SerializedName("challengerProfileImage") val challengerProfileImage: String?,
+    @SerializedName("school") val school: String,
+    @SerializedName("part") val part: String,
+    @SerializedName("title") val title: String,
+    @SerializedName("content") val content: String,
+    @SerializedName("url") val url: String
+) {
+    companion object{
+        fun TrophyResponse.toTrophyBody() : TrophyBody{
+            val userPart = try {
+                UserPart.valueOf(this.part)
+            } catch (e: Exception) {
+                UserPart.UNKNOWN
+            }
+
+            return TrophyBody(
+                trophyId = this.trophyId,
+                challengerId = this.challengerId,
+                week = this.week.toIntOrNull() ?: 0,
+                challengerName = this.challengerName,
+                challengerProfileImage = this.challengerProfileImage ?: "",
+                school = this.school,
+                part = userPart,
+                title = this.title,
+                content = this.content,
+                url = this.url
+            )
+        }
+
+    }
+
+}

--- a/domain/src/main/java/com/umc/domain/model/community/TrophyItem.kt
+++ b/domain/src/main/java/com/umc/domain/model/community/TrophyItem.kt
@@ -1,0 +1,30 @@
+package com.umc.domain.model.community
+
+import com.umc.domain.model.enums.UserPart
+
+sealed class TrophyItem {
+    data class Header(val schoolName: String) : TrophyItem()
+    data class Content(val data: TrophyBody) : TrophyItem()
+}
+
+// 서버 응답
+data class TrophyBody(
+    val trophyId: Long,
+    val challengerId: Long,
+    val week: Int,
+    val challengerName: String,
+    val challengerProfileImage: String,
+    val school: String,
+    val part: UserPart,
+    val title: String,
+    val content: String,
+    val url: String
+)
+
+data class TrophyWrite(
+    val challengerId: Long,
+    val week: Int,
+    val title: String,
+    val content: String,
+    val url: String
+)

--- a/domain/src/main/java/com/umc/domain/model/enums/CommunityCategoryType.kt
+++ b/domain/src/main/java/com/umc/domain/model/enums/CommunityCategoryType.kt
@@ -3,8 +3,6 @@ package com.umc.domain.model.enums
 //커뮤니티에서의 카테고리 타입
 enum class CommunityCategoryType(val label: String) {
     LIGHTNING("번개"),
-    HABIT("취미"),
     QUESTION("질문"),
-    INFORMATION("정보"),
     FREE("자유"),
 }

--- a/domain/src/main/java/com/umc/domain/model/enums/TrophySchoolType.kt
+++ b/domain/src/main/java/com/umc/domain/model/enums/TrophySchoolType.kt
@@ -1,0 +1,19 @@
+package com.umc.domain.model.enums
+
+enum class TrophySchoolType(val korName: String) {
+    CAU("중앙대학교"),
+    SWU("서울여자대학교"),
+    ALL("전체");
+
+
+    companion object {
+
+        fun getSchoolLabels(): List<String> {
+            return entries
+                .filter { it != ALL }
+                .map { it.korName }
+                .sorted()
+        }
+    }
+
+}

--- a/domain/src/main/java/com/umc/domain/model/enums/UserPart.kt
+++ b/domain/src/main/java/com/umc/domain/model/enums/UserPart.kt
@@ -19,6 +19,13 @@ enum class UserPart(val label: String) {
                 it.name.replace("_", "") == value.replace("_", "")
             } ?: UNKNOWN
         }
+
+        fun getFilterLabels(): List<String> {
+            return entries
+                .filter { it != UNKNOWN }
+                .map { it.label }
+        }
+
     }
 
 }

--- a/domain/src/main/java/com/umc/domain/repository/community/CommunityRepository.kt
+++ b/domain/src/main/java/com/umc/domain/repository/community/CommunityRepository.kt
@@ -8,6 +8,8 @@ import com.umc.domain.model.community.CreatePost
 import com.umc.domain.model.community.PostLike
 import com.umc.domain.model.community.PostPageModel
 import com.umc.domain.model.community.PostScrap
+import com.umc.domain.model.community.TrophyBody
+import com.umc.domain.model.community.TrophyWrite
 
 interface CommunityRepository {
 
@@ -67,5 +69,13 @@ interface CommunityRepository {
 
     //댓글 신고
     suspend fun reportComment(commentId: Long): ApiState<Unit>
+
+    //명예의전당 게시글 생성
+    suspend fun createTrophy(request: TrophyWrite): ApiState<TrophyBody>
+
+    //명예의전당 게시글 불러오기
+    suspend fun getTrophies(week: Int?, school: String?, part: String?): ApiState<List<TrophyBody>>
+
+
 }
 

--- a/domain/src/main/java/com/umc/domain/usecase/community/CreateCommunityTrophyUseCase.kt
+++ b/domain/src/main/java/com/umc/domain/usecase/community/CreateCommunityTrophyUseCase.kt
@@ -1,0 +1,12 @@
+package com.umc.domain.usecase.community
+
+import com.umc.domain.model.community.TrophyWrite
+import com.umc.domain.repository.community.CommunityRepository
+import javax.inject.Inject
+
+class CreateCommunityTrophyUseCase @Inject constructor(
+    private val communityRepository: CommunityRepository
+) {
+    suspend operator fun invoke(request: TrophyWrite) =
+        communityRepository.createTrophy(request)
+}

--- a/domain/src/main/java/com/umc/domain/usecase/community/GetCommunityTrophyUseCase.kt
+++ b/domain/src/main/java/com/umc/domain/usecase/community/GetCommunityTrophyUseCase.kt
@@ -1,0 +1,11 @@
+package com.umc.domain.usecase.community
+
+import com.umc.domain.repository.community.CommunityRepository
+import javax.inject.Inject
+
+class GetCommunityTrophyUseCase @Inject constructor(
+    private val communityRepository: CommunityRepository
+) {
+    suspend operator fun invoke(week: Int?, school: String?, part: String?) =
+        communityRepository.getTrophies(week, school, part)
+}

--- a/presentation/src/main/java/com/umc/presentation/ui/community/adapter/BottomSheetTrophyCategoryAdapter.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/community/adapter/BottomSheetTrophyCategoryAdapter.kt
@@ -7,9 +7,9 @@ import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.umc.presentation.databinding.ItemBottomSheetCategoryBinding
 
-class BottomSheetTropyCategoryAdapter(
+class BottomSheetTrophyCategoryAdapter(
     private val onClick: (String) -> Unit
-) : ListAdapter<String, BottomSheetTropyCategoryAdapter.ViewHolder>(CategoryDiffCallback) {
+) : ListAdapter<String, BottomSheetTrophyCategoryAdapter.ViewHolder>(CategoryDiffCallback) {
 
     inner class ViewHolder(private val binding: ItemBottomSheetCategoryBinding) :
         RecyclerView.ViewHolder(binding.root) {

--- a/presentation/src/main/java/com/umc/presentation/ui/community/adapter/BottomSheetTropyCategoryAdapter.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/community/adapter/BottomSheetTropyCategoryAdapter.kt
@@ -1,0 +1,46 @@
+package com.umc.presentation.ui.community.adapter
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.umc.presentation.databinding.ItemBottomSheetCategoryBinding
+
+class BottomSheetTropyCategoryAdapter(
+    private val onClick: (String) -> Unit
+) : ListAdapter<String, BottomSheetTropyCategoryAdapter.ViewHolder>(CategoryDiffCallback) {
+
+    inner class ViewHolder(private val binding: ItemBottomSheetCategoryBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+
+        fun bind(category: String) {
+            binding.itemTvCategory.text = category
+
+            binding.root.setOnClickListener {
+                onClick(category)
+            }
+        }
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+        val binding = ItemBottomSheetCategoryBinding.inflate(
+            LayoutInflater.from(parent.context), parent, false
+        )
+        return ViewHolder(binding)
+    }
+
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        holder.bind(getItem(position))
+    }
+
+    companion object CategoryDiffCallback : DiffUtil.ItemCallback<String>() {
+        override fun areItemsTheSame(oldItem: String, newItem: String): Boolean {
+            return oldItem == newItem
+        }
+
+        override fun areContentsTheSame(oldItem: String, newItem: String): Boolean {
+            return oldItem == newItem
+        }
+    }
+}

--- a/presentation/src/main/java/com/umc/presentation/ui/community/adapter/ShowCategoryAdapter.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/community/adapter/ShowCategoryAdapter.kt
@@ -1,4 +1,4 @@
-package com.umc.presentation.ui.home.adapter
+package com.umc.presentation.ui.community.adapter
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
@@ -10,12 +10,12 @@ import com.umc.domain.model.home.CategoryItem
 import com.umc.presentation.R
 import com.umc.presentation.databinding.ItemHomeCategoryBinding
 
-
 /**해당 어댑터는 카테고리 (UChip) 형태에 대한 어댑터입니다.
  * 게시글 카테고리의 경우 종류가 많으므로, CategoryType의 enums를 생성하고 label로 처리하러 했으나
  * 중아 건의함의 카테고리의 경우, 지역이기 때문에, String으로 통합
  *
  * TODO: 해당 어댑터는 일정 추가 탭의 BottomSheetdDialog 사용으로 인해 사용이 중지되었습니다.
+ * TODO: 2026 02.23 -> 커뮤니티 화면의 명예의 전당에서 사용됩니다.
  * **/
 class ShowCategoryAdapter(
     private val onCategoryClick: (CategoryItem) -> Unit,

--- a/presentation/src/main/java/com/umc/presentation/ui/community/adapter/TrophyDetailAdapter.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/community/adapter/TrophyDetailAdapter.kt
@@ -1,0 +1,92 @@
+package com.umc.presentation.ui.community.adapter
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import coil.load
+import com.umc.domain.model.community.TrophyBody
+import com.umc.domain.model.community.TrophyItem
+import com.umc.presentation.R
+import com.umc.presentation.databinding.ItemCommunityTrophyBinding
+import com.umc.presentation.databinding.ItemCommunityTrophySchoolBinding
+
+class TrophyDetailAdapter (
+    private val onContentClick: (TrophyBody) -> Unit
+) : ListAdapter<TrophyItem, RecyclerView.ViewHolder>(TrophyDiffCallback) {
+
+    companion object {
+        private const val TYPE_HEADER = 0
+        private const val TYPE_CONTENT = 1
+    }
+
+    override fun getItemViewType(position: Int): Int {
+        return when (getItem(position)) {
+            is TrophyItem.Header -> TYPE_HEADER
+            is TrophyItem.Content -> TYPE_CONTENT
+        }
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
+        val inflater = LayoutInflater.from(parent.context)
+        return when (viewType) {
+            TYPE_HEADER -> {
+                val binding = ItemCommunityTrophySchoolBinding.inflate(inflater, parent, false)
+                HeaderViewHolder(binding)
+            }
+            else -> {
+                val binding = ItemCommunityTrophyBinding.inflate(inflater, parent, false)
+                ContentViewHolder(binding)
+            }
+        }
+    }
+
+    override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
+        val item = getItem(position)
+        when (holder) {
+            is HeaderViewHolder -> holder.bind((item as TrophyItem.Header).schoolName)
+            is ContentViewHolder -> holder.bind((item as TrophyItem.Content).data)
+        }
+    }
+
+    inner class HeaderViewHolder(private val binding: ItemCommunityTrophySchoolBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+        fun bind(schoolName: String) {
+            binding.schoolName = schoolName
+            binding.executePendingBindings()
+        }
+    }
+
+    inner class ContentViewHolder(private val binding: ItemCommunityTrophyBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+        fun bind(body: TrophyBody) {
+            binding.item = body
+            binding.itemCircleimvProfile.load(body.challengerProfileImage) {
+                crossfade(true)
+                placeholder(R.drawable.ic_profile_default)
+                error(R.drawable.ic_profile_default)
+            }
+
+            //버튼 클릭 시
+            binding.itemBtnGo.setOnClickListener { onContentClick(body) }
+            binding.executePendingBindings()
+        }
+    }
+
+    object TrophyDiffCallback : DiffUtil.ItemCallback<TrophyItem>() {
+        override fun areItemsTheSame(oldItem: TrophyItem, newItem: TrophyItem): Boolean {
+            return when {
+                oldItem is TrophyItem.Header && newItem is TrophyItem.Header ->
+                    oldItem.schoolName == newItem.schoolName
+                oldItem is TrophyItem.Content && newItem is TrophyItem.Content ->
+                    oldItem.data.trophyId == newItem.data.trophyId
+                else -> false
+            }
+        }
+
+        override fun areContentsTheSame(oldItem: TrophyItem, newItem: TrophyItem): Boolean {
+            return oldItem == newItem
+        }
+    }
+}

--- a/presentation/src/main/java/com/umc/presentation/ui/community/top/TopPostFragment.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/community/top/TopPostFragment.kt
@@ -4,21 +4,28 @@ package com.umc.presentation.ui.community.top
 import androidx.fragment.app.viewModels
 import com.umc.presentation.base.BaseFragment
 import com.umc.presentation.databinding.FragmentTopPostBinding
+import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 import kotlin.getValue
 
 
+@AndroidEntryPoint
 class TopPostFragment : BaseFragment<FragmentTopPostBinding, TopPostFragmentUiState, TopPostFragmentEvent, TopPostViewModel>(
     FragmentTopPostBinding::inflate
 ) {
 
     override val viewModel : TopPostViewModel by viewModels()
 
+
     override fun initView() {
         binding.apply {
             vm = viewModel
             lifecycleOwner = viewLifecycleOwner
         }
+
+        //뷰모델에서 불러오기
+        viewModel.fetchTrophies(null, null, null)
+
     }
 
     override fun initStates() {

--- a/presentation/src/main/java/com/umc/presentation/ui/community/top/TopPostFragment.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/community/top/TopPostFragment.kt
@@ -6,6 +6,8 @@ import android.net.Uri
 import androidx.core.net.toUri
 import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.LinearLayoutManager
+import com.umc.domain.model.enums.TrophySchoolType
+import com.umc.domain.model.enums.UserPart
 import com.umc.presentation.base.BaseFragment
 import com.umc.presentation.databinding.FragmentTopPostBinding
 import com.umc.presentation.ui.community.adapter.ShowCategoryAdapter
@@ -67,6 +69,37 @@ class TopPostFragment : BaseFragment<FragmentTopPostBinding, TopPostFragmentUiSt
 
     override fun handleEvent(event: TopPostFragmentEvent) {
         super.handleEvent(event)
+
+        when(event){
+            is TopPostFragmentEvent.OnClickSchoolMenu -> {
+                /**TODO: enum을 이용해 학교 이름을 정의한다. - 차후 학교 변동 시 enum 수정**/
+                val schools = TrophySchoolType.getSchoolLabels()
+                TrophyBottomSheetDialog(
+                    title = "학교를 선택하세요",
+                    content = "가나다순으로 정렬되어 있어요",
+                    itemList = schools,
+                    onSelected = {selectedSchool ->
+                        viewModel.handleSelectSchool(selectedSchool)
+                    }
+                ).show(childFragmentManager, "SchoolBottomSheetDialog")
+
+            }
+            is TopPostFragmentEvent.OnClickPartMenu -> {
+                val parts = UserPart.getFilterLabels()
+                TrophyBottomSheetDialog(
+                    title = "파트를 선택하세요",
+                    content = null,
+                    itemList = parts,
+                    onSelected = {selectedPart ->
+                        viewModel.handleSelectPart(selectedPart)
+                    }
+                ).show(childFragmentManager, "PartBottomSheetDialog")
+
+            }
+            else -> {
+
+            }
+        }
 
     }
 

--- a/presentation/src/main/java/com/umc/presentation/ui/community/top/TopPostFragment.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/community/top/TopPostFragment.kt
@@ -1,9 +1,15 @@
 package com.umc.presentation.ui.community.top
 
 
+import android.content.Intent
+import android.net.Uri
+import androidx.core.net.toUri
 import androidx.fragment.app.viewModels
+import androidx.recyclerview.widget.LinearLayoutManager
 import com.umc.presentation.base.BaseFragment
 import com.umc.presentation.databinding.FragmentTopPostBinding
+import com.umc.presentation.ui.community.adapter.ShowCategoryAdapter
+import com.umc.presentation.ui.community.adapter.TrophyDetailAdapter
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 import kotlin.getValue
@@ -16,6 +22,11 @@ class TopPostFragment : BaseFragment<FragmentTopPostBinding, TopPostFragmentUiSt
 
     override val viewModel : TopPostViewModel by viewModels()
 
+    //주차별 선택 어댑터
+    private lateinit var weekAdapter : ShowCategoryAdapter
+
+    //명예의전당 본문 어댑터
+    private lateinit var trophyAdapter : TrophyDetailAdapter
 
     override fun initView() {
         binding.apply {
@@ -23,8 +34,14 @@ class TopPostFragment : BaseFragment<FragmentTopPostBinding, TopPostFragmentUiSt
             lifecycleOwner = viewLifecycleOwner
         }
 
-        //뷰모델에서 불러오기
-        viewModel.fetchTrophies(null, null, null)
+        //주차 어댑터 설정
+        setWeekAdapter()
+        //본문 어댑터
+        setTrophyAdapter()
+        
+        //뷰모델에서 불러오기(초기는 null)
+        viewModel.fetchTrophies(1, null, null)
+        
 
     }
 
@@ -34,7 +51,8 @@ class TopPostFragment : BaseFragment<FragmentTopPostBinding, TopPostFragmentUiSt
         repeatOnStarted(viewLifecycleOwner) {
             launch {
                 viewModel.uiState.collect { state ->
-
+                    weekAdapter.submitList(state.weekList)
+                    trophyAdapter.submitList(state.uiTrophyList)
                 }
             }
 
@@ -49,7 +67,56 @@ class TopPostFragment : BaseFragment<FragmentTopPostBinding, TopPostFragmentUiSt
 
     override fun handleEvent(event: TopPostFragmentEvent) {
         super.handleEvent(event)
+
     }
+
+    //명예의전당 본문 recyclerview 초기화
+    private fun setTrophyAdapter(){
+        trophyAdapter = TrophyDetailAdapter { item ->
+            //터치한 링크로 이동하는 로직
+            openWebpage(item.url)
+        }
+        binding.topRcvCotent.apply {
+            adapter = trophyAdapter
+            layoutManager = LinearLayoutManager(requireContext())
+        }
+    }
+
+    //주차별 recyclerview 초기화
+    private fun setWeekAdapter(){
+        viewModel.initWeekList() //먼저 초기화
+
+        weekAdapter = ShowCategoryAdapter { category ->
+            viewModel.handleSelectWeek(category)
+        }
+        binding.topRcvWeek.apply {
+            adapter = weekAdapter
+            layoutManager = LinearLayoutManager(requireContext(), LinearLayoutManager.HORIZONTAL, false)
+
+            itemAnimator = null
+        }
+    }
+
+    //웹페이지 이동
+    private fun openWebpage(url: String) {
+        try {
+            val webpage: Uri = url.toUri()
+            val intent = Intent(Intent.ACTION_VIEW, webpage)
+            startActivity(intent)
+            //브라우저를 실행할 수 있는 앱이 있는지 확인
+            if (intent.resolveActivity(requireContext().packageManager) != null) {
+                startActivity(intent)
+            } else {
+                // 브라우저조차 없는 특수한 상황
+                val webIntent = Intent(Intent.ACTION_VIEW, webpage)
+                startActivity(webIntent)
+            }
+        }
+        catch (e: Exception){
+            e.printStackTrace()
+        }
+    }
+
 
 }
 

--- a/presentation/src/main/java/com/umc/presentation/ui/community/top/TopPostViewModel.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/community/top/TopPostViewModel.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import androidx.lifecycle.viewModelScope
 import com.umc.domain.model.community.TrophyBody
 import com.umc.domain.model.community.TrophyItem
+import com.umc.domain.model.enums.UserPart
 import com.umc.domain.model.home.CategoryItem
 import com.umc.domain.usecase.community.GetCommunityTrophyUseCase
 
@@ -86,6 +87,26 @@ BaseViewModel<TopPostFragmentUiState, TopPostFragmentEvent>(
 
     }
 
+    //선택한 학교 선택 및 호출
+    fun handleSelectSchool(schoolName: String){
+        updateState {
+            copy(selectedSchool = schoolName)
+        }
+        fetchTrophies(uiState.value.selectedWeek, schoolName, uiState.value.selectedPart)
+    }
+
+    //선택한 파트 선택 및 호출
+    fun handleSelectPart(partName: String) {
+        //저장은 서버에 보내주는 양식을 저장(name)
+        val partEnum = UserPart.entries.find { it.label == partName } ?: UserPart.UNKNOWN
+        updateState {
+            copy(selectedPart = partEnum.name)
+        }
+        fetchTrophies(uiState.value.selectedWeek, uiState.value.selectedSchool, partName)
+    }
+
+
+
 
     //주차 리스트 최신화하여 recyclerview에 줄 인자 정하기
     fun initWeekList(){
@@ -107,6 +128,15 @@ BaseViewModel<TopPostFragmentUiState, TopPostFragmentEvent>(
             copy(weekList = weekList,
             selectedWeek = 1)
         }
+    }
+    
+    //학교 메뉴 선택
+    fun onClickSchoolMenu(){
+        emitEvent(TopPostFragmentEvent.OnClickSchoolMenu)
+    }
+    //파트 메뉴 선택
+    fun onClickPartMenu(){
+        emitEvent(TopPostFragmentEvent.OnClickPartMenu)
     }
 }
 
@@ -130,9 +160,17 @@ data class TopPostFragmentUiState(
     val selectedPart: String? = null,
 
 
-    ) : UiState
+    ) : UiState {
+    //참여자 명단(recyclerview를 보여주는지 체크 여부)
+    val isShow: Boolean
+        get() = trophyList.isNotEmpty()
+}
 
 sealed interface TopPostFragmentEvent : UiEvent {
+
+    object OnClickSchoolMenu: TopPostFragmentEvent
+    object OnClickPartMenu: TopPostFragmentEvent
+
 
 
 }

--- a/presentation/src/main/java/com/umc/presentation/ui/community/top/TopPostViewModel.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/community/top/TopPostViewModel.kt
@@ -1,29 +1,52 @@
 package com.umc.presentation.ui.community.top
 
-import com.umc.domain.model.community.ContentItem
-import com.umc.domain.model.enums.SearchMode
+import android.util.Log
+import androidx.lifecycle.viewModelScope
+import com.umc.domain.model.community.TrophyBody
+import com.umc.domain.usecase.community.GetCommunityTrophyUseCase
+
 import com.umc.presentation.base.BaseViewModel
 import com.umc.presentation.base.UiEvent
 import com.umc.presentation.base.UiState
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-
-class TopPostViewModel @Inject constructor() :
+class TopPostViewModel @Inject constructor(
+    private val getTrophyUseCase: GetCommunityTrophyUseCase
+) :
 BaseViewModel<TopPostFragmentUiState, TopPostFragmentEvent>(
     TopPostFragmentUiState()
 ) {
 
+
+    //명예의전당게시글 가져오기
+    fun fetchTrophies(week: Int?, school: String?, part: String?){
+        viewModelScope.launch {
+            resultResponse(
+                response = getTrophyUseCase(week, school, part),
+                successCallback = { trophies ->
+                    updateState { copy(trophyList = trophies)}
+                    Log.d("log_community", trophies.toString())
+                },
+                errorCallback = {
+                    updateState { copy(trophyList = emptyList()) }
+                }
+            )
+
+        }
+    }
 }
 
 
 
 data class TopPostFragmentUiState(
 
-    val dummy : String = "",
+    //서버에서 받아온 리스트
+    val trophyList : List<TrophyBody> = listOf(),
 
-) : UiState
+    ) : UiState
 
 sealed interface TopPostFragmentEvent : UiEvent {
 

--- a/presentation/src/main/java/com/umc/presentation/ui/community/top/TopPostViewModel.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/community/top/TopPostViewModel.kt
@@ -3,6 +3,8 @@ package com.umc.presentation.ui.community.top
 import android.util.Log
 import androidx.lifecycle.viewModelScope
 import com.umc.domain.model.community.TrophyBody
+import com.umc.domain.model.community.TrophyItem
+import com.umc.domain.model.home.CategoryItem
 import com.umc.domain.usecase.community.GetCommunityTrophyUseCase
 
 import com.umc.presentation.base.BaseViewModel
@@ -10,6 +12,7 @@ import com.umc.presentation.base.UiEvent
 import com.umc.presentation.base.UiState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
+import java.util.Calendar
 import javax.inject.Inject
 
 @HiltViewModel
@@ -21,20 +24,88 @@ BaseViewModel<TopPostFragmentUiState, TopPostFragmentEvent>(
 ) {
 
 
-    //명예의전당게시글 가져오기
+    //명예의 전당게시글 가져오기
     fun fetchTrophies(week: Int?, school: String?, part: String?){
         viewModelScope.launch {
             resultResponse(
                 response = getTrophyUseCase(week, school, part),
                 successCallback = { trophies ->
-                    updateState { copy(trophyList = trophies)}
-                    Log.d("log_community", trophies.toString())
+                    val uiItems = processTrophyList(trophies)
+                    updateState {
+                        copy(
+                            trophyList = trophies,
+                            uiTrophyList = uiItems
+                        )
+                    }
+
                 },
                 errorCallback = {
                     updateState { copy(trophyList = emptyList()) }
                 }
             )
 
+        }
+    }
+
+    //서버에서 가져온 값을 파싱해서 어댑터에 전송 가능하게 만들기
+    fun processTrophyList(trophyList: List<TrophyBody>): List<TrophyItem>{
+        //최종 아이템이 들어올 곳
+        val uiItems = mutableListOf<TrophyItem>()
+
+        //학교 이름별 그룹 (Map<String, List<TrophyBody>>)
+        val groupedBySchool = trophyList.groupBy { it.school }
+
+        groupedBySchool.forEach { (schoolName, items) ->
+            //학교 이름 헤더 추가
+            uiItems.add(TrophyItem.Header(schoolName))
+
+            //해당 학교에 속한 사람들 추가
+            items.forEach { body ->
+                uiItems.add(TrophyItem.Content(body))
+            }
+        }
+
+        return uiItems
+    }
+
+    //선택한 주차 선택 및 호출
+    fun handleSelectWeek(item: CategoryItem){
+        //선택한 것 외에 다 false 로 바꾸는 로직 (UI 바꾸기)
+        val updatedWeekList = uiState.value.weekList.map{
+            it.copy(isChecked = it.name == item.name)
+
+        }
+        updateState {
+            copy(weekList = updatedWeekList)
+        }
+
+        //정수만 뽑아내는 코드)
+        val selectedWeek = item.name.replace("""\D""".toRegex(), "").toIntOrNull() ?: 1
+        //다시 서버에서 값을 가져오기
+        fetchTrophies(selectedWeek, uiState.value.selectedSchool, uiState.value.selectedPart)
+
+    }
+
+
+    //주차 리스트 최신화하여 recyclerview에 줄 인자 정하기
+    fun initWeekList(){
+        val calendar = Calendar.getInstance()
+
+        //가장 마지막 날로 이동
+        calendar.set(Calendar.DAY_OF_MONTH, calendar.getActualMaximum(Calendar.DAY_OF_MONTH))
+
+        //이번 달의 총 주차 수 가져오기
+        val maxWeeks = calendar.get(Calendar.WEEK_OF_MONTH)
+
+        val weekList = (1..maxWeeks).map { week ->
+            CategoryItem(
+                name = "${week}주차",
+                isChecked = week == 1 //기본값으로 1주차 선택
+            )
+        }
+        updateState {
+            copy(weekList = weekList,
+            selectedWeek = 1)
         }
     }
 }
@@ -45,6 +116,19 @@ data class TopPostFragmentUiState(
 
     //서버에서 받아온 리스트
     val trophyList : List<TrophyBody> = listOf(),
+
+    //recylcerview에 보여줄 리스트
+    val uiTrophyList : List<TrophyItem> = listOf(),
+
+
+    //이번 달 몇주까지 있는지 리스트
+    val weekList : List<CategoryItem> = emptyList(),
+
+    //필터링 요소
+    val selectedWeek: Int? = 1,
+    val selectedSchool: String? = null,
+    val selectedPart: String? = null,
+
 
     ) : UiState
 

--- a/presentation/src/main/java/com/umc/presentation/ui/community/top/TopPostViewModel.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/community/top/TopPostViewModel.kt
@@ -100,9 +100,9 @@ BaseViewModel<TopPostFragmentUiState, TopPostFragmentEvent>(
         //저장은 서버에 보내주는 양식을 저장(name)
         val partEnum = UserPart.entries.find { it.label == partName } ?: UserPart.UNKNOWN
         updateState {
-            copy(selectedPart = partEnum.name)
+            copy(selectedPart = partName)
         }
-        fetchTrophies(uiState.value.selectedWeek, uiState.value.selectedSchool, partName)
+        fetchTrophies(uiState.value.selectedWeek, uiState.value.selectedSchool, partEnum.name)
     }
 
 

--- a/presentation/src/main/java/com/umc/presentation/ui/community/top/TrophyBottomSheetDialog.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/community/top/TrophyBottomSheetDialog.kt
@@ -1,0 +1,76 @@
+package com.umc.presentation.ui.community.top
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import com.google.android.material.bottomsheet.BottomSheetBehavior
+import com.google.android.material.bottomsheet.BottomSheetDialog
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import com.umc.presentation.R
+import com.umc.presentation.databinding.LayoutBottomSheetCategoryBinding
+import com.umc.presentation.ui.community.adapter.BottomSheetTrophyCategoryAdapter
+
+class TrophyBottomSheetDialog (
+    private val title: String,          // 바텀시트 상단 제목
+    private val content: String?,       // 하단 설명 (유무)
+    private val itemList: List<String>, // 보여줄 데이터 리스트
+    private val onSelected: (String) -> Unit
+) : BottomSheetDialogFragment() {
+    private lateinit var binding: LayoutBottomSheetCategoryBinding
+
+    override fun getTheme(): Int = R.style.TransparentBottomSheetDialogTheme
+
+    override fun onStart() {
+        super.onStart()
+
+        // 다이얼로그의 내부 뷰(design_bottom_sheet)를 찾아 높이를 설정
+        (dialog as? BottomSheetDialog)?.findViewById<View>(com.google.android.material.R.id.design_bottom_sheet)?.let { bottomSheet ->
+            val behavior = BottomSheetBehavior.from(bottomSheet)
+
+            // 1. 레이아웃 파라미터의 높이를 화면 전체의 80%로 설정
+            val layoutParams = bottomSheet.layoutParams
+            layoutParams.height = (resources.displayMetrics.heightPixels * 0.7).toInt()
+            bottomSheet.layoutParams = layoutParams
+
+            // 2. 초기 상태를 확장 상태(EXPANDED)로 고정
+            behavior.state = BottomSheetBehavior.STATE_EXPANDED
+
+            // 3. 드래그해서 절반으로 접히는 현상 방지 (선택 사항)
+            behavior.skipCollapsed = true
+        }
+    }
+
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        binding = LayoutBottomSheetCategoryBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        //ui 연결
+        binding.tvTitle.text = title
+        if(content != null) {
+            binding.tvContent.visibility = View.VISIBLE
+            binding.tvContent.text = content
+        }
+
+        //어댑터 초기화 및 클릭 리스너 연결
+        val categoryAdapter = BottomSheetTrophyCategoryAdapter { selectedItem ->
+            onSelected(selectedItem)
+            dismiss() //다이얼로그 닫기
+        }
+
+        //리사이클러뷰 설정
+        binding.rvCategories.adapter = categoryAdapter
+
+        //데이터 주입 (Enum의 모든 항목)
+        categoryAdapter.submitList(itemList)
+    }
+}

--- a/presentation/src/main/java/com/umc/presentation/ui/community/write/PostWriteFragment.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/community/write/PostWriteFragment.kt
@@ -17,7 +17,7 @@ import com.umc.presentation.base.BaseFragment
 import com.umc.presentation.databinding.FragmentPostWriteBinding
 import com.umc.presentation.ui.community.adapter.BottomSheetCategoryAdapter
 import com.umc.presentation.ui.community.detail.PostDetailFragmentArgs
-import com.umc.presentation.ui.home.adapter.ShowCategoryAdapter
+import com.umc.presentation.ui.community.adapter.ShowCategoryAdapter
 import com.umc.presentation.util.UToast
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch

--- a/presentation/src/main/res/layout/fragment_top_post.xml
+++ b/presentation/src/main/res/layout/fragment_top_post.xml
@@ -11,27 +11,130 @@
             type="com.umc.presentation.ui.community.top.TopPostViewModel" />
     </data>
 
-    <!--이미 containerview에 패딩 있으니 상관 X-->
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:paddingVertical="24dp"
+        android:paddingTop="24dp"
         android:paddingHorizontal="16dp"
         android:background="@color/neutral100"
         >
 
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/top_rcv_week"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            app:layout_constraintTop_toTopOf="parent"
+            />
 
-        <TextView
+        <!--대학교 파트-->
+        <com.google.android.material.card.MaterialCardView
+            android:id="@+id/top_cdv_category_school"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="현재 지원하지 않는 기능입니다."
-            android:textAppearance="@style/Footnote"
-            android:textColor="@color/neutral800"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintBottom_toBottomOf="parent"
+            android:background="@color/neutral000"
+            android:layout_marginTop="16dp"
+
+            app:cardBackgroundColor="@color/neutral000"
+            app:strokeWidth="1dp"
+            app:strokeColor="@color/neutral200"
+            app:cardCornerRadius="8dp"
+            app:cardElevation="0dp"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/top_rcv_week">
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:paddingVertical="8dp"
+                android:paddingHorizontal="12dp">
+
+                <TextView
+                    android:id="@+id/top_tv_school_select"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:gravity="start"
+                    android:textAppearance="@style/CalloutBold"
+                    android:textColor="@color/neutral500"
+                    android:text='@{vm.uiState.selectedSchool == null ? "대학교" : vm.uiState.selectedSchool}'
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    />
+
+                <ImageView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:src="@drawable/ic_dropdown"
+                    android:layout_marginStart="4dp"
+                    android:tint="@color/neutral400"
+                    app:layout_constraintStart_toEndOf="@id/top_tv_school_select"
+                    app:layout_constraintTop_toTopOf="@id/top_tv_school_select"
+                    app:layout_constraintBottom_toBottomOf="@id/top_tv_school_select"/>
+
+            </androidx.constraintlayout.widget.ConstraintLayout>
+        </com.google.android.material.card.MaterialCardView>
+
+        <!--파트-->
+        <com.google.android.material.card.MaterialCardView
+            android:id="@+id/top_cdv_category_userpart"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:background="@color/neutral000"
+            android:layout_marginTop="16dp"
+            android:layout_marginStart="8dp"
+
+            app:cardBackgroundColor="@color/neutral000"
+            app:strokeWidth="1dp"
+            app:strokeColor="@color/neutral200"
+            app:cardCornerRadius="8dp"
+            app:cardElevation="0dp"
+            app:layout_constraintStart_toEndOf="@id/top_cdv_category_school"
+            app:layout_constraintTop_toBottomOf="@id/top_rcv_week">
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:paddingVertical="8dp"
+                android:paddingHorizontal="12dp">
+
+                <TextView
+                    android:id="@+id/top_tv_userpart_select"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:gravity="start"
+                    android:textAppearance="@style/CalloutBold"
+                    android:textColor="@color/neutral500"
+                    android:text='@{vm.uiState.selectedPart == null ? "파트" : vm.uiState.selectedPart}'
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    />
+
+                <ImageView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:src="@drawable/ic_dropdown"
+                    android:layout_marginStart="4dp"
+                    android:tint="@color/neutral400"
+                    app:layout_constraintStart_toEndOf="@id/top_tv_userpart_select"
+                    app:layout_constraintTop_toTopOf="@id/top_tv_userpart_select"
+                    app:layout_constraintBottom_toBottomOf="@id/top_tv_userpart_select"/>
+
+            </androidx.constraintlayout.widget.ConstraintLayout>
+
+        </com.google.android.material.card.MaterialCardView>
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/top_rcv_cotent"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:orientation="vertical"
+            android:layout_marginTop="4dp"
+            app:layout_constraintTop_toBottomOf="@id/top_cdv_category_school"
+            app:layout_constraintBottom_toBottomOf="parent"
             />
+
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/presentation/src/main/res/layout/fragment_top_post.xml
+++ b/presentation/src/main/res/layout/fragment_top_post.xml
@@ -6,6 +6,8 @@
 
     <data>
 
+        <import type="android.view.View"/>
+
         <variable
             name="vm"
             type="com.umc.presentation.ui.community.top.TopPostViewModel" />
@@ -34,7 +36,7 @@
             android:layout_height="wrap_content"
             android:background="@color/neutral000"
             android:layout_marginTop="16dp"
-
+            android:onClick="@{()->vm.onClickSchoolMenu()}"
             app:cardBackgroundColor="@color/neutral000"
             app:strokeWidth="1dp"
             app:strokeColor="@color/neutral200"
@@ -83,7 +85,7 @@
             android:background="@color/neutral000"
             android:layout_marginTop="16dp"
             android:layout_marginStart="8dp"
-
+            android:onClick="@{()->vm.onClickPartMenu()}"
             app:cardBackgroundColor="@color/neutral000"
             app:strokeWidth="1dp"
             app:strokeColor="@color/neutral200"
@@ -131,9 +133,23 @@
             android:layout_height="0dp"
             android:orientation="vertical"
             android:layout_marginTop="4dp"
+            android:visibility="@{vm.uiState.isShow ? View.VISIBLE : View.GONE}"
             app:layout_constraintTop_toBottomOf="@id/top_cdv_category_school"
             app:layout_constraintBottom_toBottomOf="parent"
             />
+
+        <TextView
+            android:id="@+id/top_tv_now_result"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textAppearance="@style/Footnote"
+            android:textColor="@color/neutral800"
+            android:visibility="@{vm.uiState.isShow ? View.GONE : View.VISIBLE}"
+            android:text="@string/community_top_no_result"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/top_cdv_category_school"
+            app:layout_constraintBottom_toBottomOf="parent"/>
 
 
     </androidx.constraintlayout.widget.ConstraintLayout>

--- a/presentation/src/main/res/layout/item_community_comment.xml
+++ b/presentation/src/main/res/layout/item_community_comment.xml
@@ -72,8 +72,10 @@
             android:textColor="@color/neutral800"
             android:text="@{item.content}"
             android:layout_marginTop="4dp"
+            android:layout_marginEnd="4dp"
             app:layout_constraintStart_toStartOf="@id/item_tv_username"
             app:layout_constraintTop_toBottomOf="@id/item_tv_username"
+            app:layout_constraintEnd_toStartOf="@id/item_btn_menu"
             tools:text="홍길동(닉네임)"
             />
 

--- a/presentation/src/main/res/layout/item_community_trophy.xml
+++ b/presentation/src/main/res/layout/item_community_trophy.xml
@@ -29,6 +29,148 @@
         android:padding="16dp"
         >
 
+
+        <!--유저 정보-->
+        <com.google.android.material.imageview.ShapeableImageView
+            android:id="@+id/item_circleimv_profile"
+            android:layout_width="32dp"
+            android:layout_height="32dp"
+            android:scaleType="centerCrop"
+            android:src="@drawable/ic_profile_default"
+            app:strokeWidth="1dp"
+            app:strokeColor="@color/neutral200"
+            app:shapeAppearanceOverlay="@style/CircleImageAppearance"
+            app:layout_constraintTop_toTopOf="@id/item_tv_username"
+            app:layout_constraintBottom_toBottomOf="@id/item_tv_title"
+            app:layout_constraintStart_toStartOf="parent"
+            />
+
+        <TextView
+            android:id="@+id/item_tv_username"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:gravity="start"
+            android:textAppearance="@style/HeadlineBold"
+            android:textColor="@color/neutral800"
+            android:text="@{item.challengerName}"
+            android:layout_marginStart="16dp"
+            app:layout_constraintStart_toEndOf="@id/item_circleimv_profile"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:text="홍길동(닉네임)"
+            />
+
+        <com.umc.presentation.component.UButton
+            android:id="@+id/item_cdv_user_part"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            app:cornerRadius="4dp"
+            app:cardBackgroundColor="@color/neutral000"
+            app:borderWidth="1dp"
+            app:borderColor="@color/neutral200"
+            app:text="@{item.part.label}"
+            app:textAppearance="@style/Caption1Bold"
+            app:textColor="@color/neutral700"
+            app:buttonElevation="0"
+            app:contentPaddingBottom="4dp"
+            app:contentPaddingTop="4dp"
+            app:contentPaddingLeft="8dp"
+            app:contentPaddingRight="8dp"
+            app:layout_constraintTop_toTopOf="@id/item_tv_username"
+            app:layout_constraintBottom_toBottomOf="@id/item_tv_username"
+            app:layout_constraintStart_toEndOf="@id/item_tv_username"
+            />
+
+        <TextView
+            android:id="@+id/item_tv_title"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:gravity="start"
+            android:textAppearance="@style/Footnote"
+            android:textColor="@color/neutral600"
+            android:text="@{item.title}"
+            android:layout_marginTop="4dp"
+            app:layout_constraintStart_toStartOf="@id/item_tv_username"
+            app:layout_constraintTop_toBottomOf="@id/item_tv_username"
+            tools:text="제목입니다."
+            />
+
+        <!--게시글 이동 버튼-->
+        <com.google.android.material.card.MaterialCardView
+            android:id="@+id/item_btn_go"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            app:cardCornerRadius="8dp"
+            app:cardElevation="0dp"
+            app:strokeWidth="1dp"
+            app:strokeColor="@color/neutral300"
+            app:cardBackgroundColor="@color/neutral000"
+            app:layout_constraintTop_toTopOf="@id/item_tv_username"
+            app:layout_constraintBottom_toBottomOf="@id/item_tv_title"
+            app:layout_constraintEnd_toEndOf="parent"
+            >
+
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center"
+            android:paddingHorizontal="12dp"
+            android:paddingVertical="6dp">
+
+
+            <ImageView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:src="@drawable/ic_go_website"
+                app:tint="@color/neutral800" />
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/see"
+                android:textAppearance="@style/SubheadlineBold"
+                android:textColor="@color/neutral800"/>
+
+        </LinearLayout>
+        </com.google.android.material.card.MaterialCardView>
+
+        <!--내용-->
+        <com.google.android.material.card.MaterialCardView
+            android:id="@+id/item_card_content"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            app:cardCornerRadius="8dp"
+            app:cardElevation="0dp"
+            app:strokeWidth="0dp"
+            app:cardBackgroundColor="@color/neutral100"
+            app:layout_constraintTop_toBottomOf="@id/item_tv_title"
+            >
+
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center"
+            android:padding="10dp">
+
+            <TextView
+                android:id="@+id/item_tv_cotent"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@{item.content}"
+                android:textAppearance="@style/Footnote"
+                android:textColor="@color/neutral600"
+                tools:text="정말 잘 만든 워크북이네요"
+                />
+
+        </LinearLayout>
+        </com.google.android.material.card.MaterialCardView>
+
+
+
     </androidx.constraintlayout.widget.ConstraintLayout>
 
     </com.google.android.material.card.MaterialCardView>

--- a/presentation/src/main/res/layout/item_community_trophy.xml
+++ b/presentation/src/main/res/layout/item_community_trophy.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    >
+
+    <data>
+        <import type="com.umc.domain.model.enums.CategoryType" />
+        <import type="com.umc.domain.model.enums.CommunityCategoryType" />
+
+        <variable
+            name="item"
+            type="com.umc.domain.model.community.TrophyBody" />
+    </data>
+
+    <com.google.android.material.card.MaterialCardView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginVertical="8dp"
+        app:cardBackgroundColor="@color/neutral000"
+        app:cardCornerRadius="12dp"
+        app:cardElevation="0dp"
+        app:strokeWidth="0dp">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="16dp"
+        >
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    </com.google.android.material.card.MaterialCardView>
+
+</layout>

--- a/presentation/src/main/res/layout/item_community_trophy.xml
+++ b/presentation/src/main/res/layout/item_community_trophy.xml
@@ -100,7 +100,6 @@
             android:id="@+id/item_btn_go"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginTop="16dp"
             app:cardCornerRadius="8dp"
             app:cardElevation="0dp"
             app:strokeWidth="1dp"

--- a/presentation/src/main/res/layout/item_community_trophy_school.xml
+++ b/presentation/src/main/res/layout/item_community_trophy_school.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+        <variable
+            name="schoolName"
+            type="String" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@color/neutral100">
+
+        <TextView
+            android:id="@+id/item_tv_title"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:gravity="start"
+            android:textAppearance="@style/HeadlineBold"
+            android:textColor="@color/neutral800"
+            android:text='@{schoolName}'
+            android:paddingTop="24dp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:text="학교 "
+            />
+
+
+
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</layout>

--- a/presentation/src/main/res/layout/layout_bottom_sheet_category.xml
+++ b/presentation/src/main/res/layout/layout_bottom_sheet_category.xml
@@ -34,13 +34,25 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/view_handle" />
 
+        <TextView
+            android:id="@+id/tv_content"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:visibility="gone"
+            android:text="@string/community_write_category_select_long"
+            android:textAppearance="@style/Subheadline"
+            android:textColor="@color/neutral600"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_title" />
+
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/rv_categories"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
             app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-            app:layout_constraintTop_toBottomOf="@id/tv_title" />
+            app:layout_constraintTop_toBottomOf="@id/tv_content" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -107,6 +107,8 @@
     <string name="community_search_recent">최근 검색어</string>
     <string name="community_search_deleteall">전체 삭제</string>
 
+    <string name="community_top_no_result">게시글이 존재하지 않습니다</string>
+
     <!-- Word -->
     <string name="sign_up">회원가입</string>
     <string name="name">이름</string>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -138,6 +138,7 @@
     <string name="confirm">확인</string>
     <string name="unConfirm">미확인</string>
     <string name="edit">수정</string>
+    <string name="see">보기</string>
 
     <!-- 파트 -->
     <string name="pm">PM</string>


### PR DESCRIPTION
## #️⃣ 이슈 번호

> 관련된 이슈 번호를 적어주세요.\
> Close #122 

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 요약해주세요.

**1. 커뮤니티 댓글이 길어질 경우, 화면을 뚫는 문제 수정**

**2. 명예의 전당 구현**
- 명예의 전당 API (상장 목록 조회, 상장 생성)을 연결 및 상장 목록 조회 usecase 생성 (상장 생성은 Usecase를 생성하지 않았습니다)
- 명예의 전당 UI 구현 
  - viewType을 구분하여, 학교 이름/상장 recyclerview 구현
  - TrophyBottomSheetDialog을 이용하여, 필터링 진행 

## 📸 스크린샷 (선택 사항)
| 댓글 텍스트 넘침 수정 | 이미지 |
| :---: | :---: |
| ![KakaoTalk_20260223_221435361](https://github.com/user-attachments/assets/d53b24c4-9962-4ec6-8f8a-178119ce5fa8) |  |

## 시연 영상

https://github.com/user-attachments/assets/acb0fc37-b54e-4045-9351-c855fe255206



## 🚩 리뷰 요구사항
> 리뷰어가 중점적으로 봐주었으면 하는 부분이 있다면 작성해주세요.

- 시연 영상에서 파트 선택 시, Enum 값(대문자)이 보이는 것을 수정하였습니다. (fix 커밋 참고)

## 🏁 체크리스트
- [ ] 코딩 컨벤션을 준수했나요?
- [ ] 불필요한 로그나 주석을 제거했나요?
- [ ] 머지 대상 브랜치(Base branch)가 올바른가요?
