### PR TITLE
[Fix/#146] 마이페이지 및 일정 추가 QA 반영 및 챌린저 코드 입력 기능 추가

### DIFF
--- a/data/src/main/java/com/umc/data/api/OrganizationApi.kt
+++ b/data/src/main/java/com/umc/data/api/OrganizationApi.kt
@@ -86,7 +86,7 @@ interface OrganizationApi {
 
     @GET(Endpoints.Organization.SCHOOL_ID)
     suspend fun getSchoolDetail(
-        @Path(PATH_SCHOOL_ID) schoolId : Int,
+        @Path(PATH_SCHOOL_ID) schoolId : Long,
     ): ApiResponse<SchoolDetailResponse>
 
     @GET(Endpoints.Organization.STUDY_GROUD_NAME)

--- a/data/src/main/java/com/umc/data/dataSource/OrganizationDataSource.kt
+++ b/data/src/main/java/com/umc/data/dataSource/OrganizationDataSource.kt
@@ -42,7 +42,7 @@ interface OrganizationDataSource {
     ): ApiState<SchoolPageResponse>
     suspend fun getAllChapter(): ApiState<ChapterResponse>
     suspend fun getStudyGroupDetail(groupId: Long): ApiState<StudyGroupDetailResponse>
-    suspend fun getSchoolDetail(schoolId: Int): ApiState<SchoolDetailResponse>
+    suspend fun getSchoolDetail(schoolId: Long): ApiState<SchoolDetailResponse>
     suspend fun getMyStudyGroupList(): ApiState<MyStudyGroupListResponse>
     suspend fun getUnassignedSchool(gisuId: Int): ApiState<SchoolListResponse>
     suspend fun getSchoolLink(schoolId: Int): ApiState<SchoolLinksResponse>

--- a/data/src/main/java/com/umc/data/dataSource/remote/OrganizationRemoteDataSourceImpl.kt
+++ b/data/src/main/java/com/umc/data/dataSource/remote/OrganizationRemoteDataSourceImpl.kt
@@ -47,7 +47,7 @@ class OrganizationRemoteDataSourceImpl @Inject constructor(
     override suspend fun getStudyGroupDetail(groupId: Long): ApiState<StudyGroupDetailResponse> =
         apiCall { organizationApi.getStudyGroupDetail(groupId) }
 
-    override suspend fun getSchoolDetail(schoolId: Int): ApiState<SchoolDetailResponse> {
+    override suspend fun getSchoolDetail(schoolId: Long): ApiState<SchoolDetailResponse> {
         return apiCall { organizationApi.getSchoolDetail(schoolId) }
     }
 

--- a/data/src/main/java/com/umc/data/repository/OrganizationRepositoryImpl.kt
+++ b/data/src/main/java/com/umc/data/repository/OrganizationRepositoryImpl.kt
@@ -4,6 +4,7 @@ import com.umc.data.dataSource.OrganizationDataSource
 import com.umc.data.response.organization.*
 import com.umc.data.response.organization.GisuListResponse.Companion.toModel
 import com.umc.data.response.organization.GisuInfoResponse.Companion.toModel
+import com.umc.data.response.organization.SchoolDetailResponse.Companion.toModel
 import com.umc.data.response.organization.SchoolNameResponse.Companion.toModel
 import com.umc.domain.model.base.ApiState
 import com.umc.domain.model.base.map
@@ -68,8 +69,10 @@ class OrganizationRepositoryImpl @Inject constructor(
             )
         }
 
-    override suspend fun getSchoolDetail(schoolId: Int): ApiState<Unit> =
-        organizationDataSource.getSchoolDetail(schoolId).map { Unit } //임시
+    override suspend fun getSchoolDetail(schoolId: Long): ApiState<SchoolInfo> =
+        organizationDataSource.getSchoolDetail(schoolId).map { dto ->
+            dto.toModel()
+        } //임시
 
     override suspend fun getMyStudyGroupList(): ApiState<Unit> =
         organizationDataSource.getMyStudyGroupList().map { Unit } //임시

--- a/data/src/main/java/com/umc/data/response/organization/SchoolDetailResponse.kt
+++ b/data/src/main/java/com/umc/data/response/organization/SchoolDetailResponse.kt
@@ -1,5 +1,6 @@
 package com.umc.data.response.organization
 
+import com.umc.domain.model.school.SchoolInfo
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -12,4 +13,13 @@ data class SchoolDetailResponse(
     val logoImageLink: String,
     val createdAt: String,
     val updatedAt: String
-)
+) {
+    companion object {
+        fun SchoolDetailResponse.toModel(): SchoolInfo {
+            return SchoolInfo(
+                schoolId = schoolId,
+                schoolName = schoolName
+            )
+        }
+    }
+}

--- a/domain/src/main/java/com/umc/domain/model/home/UserInfoParseItem.kt
+++ b/domain/src/main/java/com/umc/domain/model/home/UserInfoParseItem.kt
@@ -14,7 +14,8 @@ import com.umc.domain.model.UserInfo
 data class RolePartItem(
     val role: String, //역할 (SCHOOL_PART_LEADER)
     val responsiblePart: String?, //ANDROID ...
-    val challengerId: Long
+    val challengerId: Long,
+    val organizationId: Long,
 )
 
 // 2. 기수별 최종 요약 모델
@@ -44,7 +45,8 @@ fun UserInfo.getGisuSummaryList(): List<GisuSummary> {
                 RolePartItem(
                     role = it.roleType,
                     responsiblePart = it.responsiblePart,
-                    challengerId = it.challengerId
+                    challengerId = it.challengerId,
+                    organizationId = it.organizationId ?: -1,
                 )
             }
 
@@ -55,7 +57,8 @@ fun UserInfo.getGisuSummaryList(): List<GisuSummary> {
                 RolePartItem(
                     role = "CHALLENGER",
                     responsiblePart = it.part,
-                    challengerId = it.challengerId
+                    challengerId = it.challengerId,
+                    organizationId = -1, //챌린저는 조직 ID 제거
                 )
             }
 

--- a/domain/src/main/java/com/umc/domain/repository/OrganizationRepository.kt
+++ b/domain/src/main/java/com/umc/domain/repository/OrganizationRepository.kt
@@ -42,7 +42,7 @@ interface OrganizationRepository {
 
     suspend fun getStudyGroupDetail(groupId: Long): ApiState<StudyGroupDetail>
 
-    suspend fun getSchoolDetail(schoolId: Int): ApiState<Unit> //SchoolDetailResponse
+    suspend fun getSchoolDetail(schoolId: Long): ApiState<SchoolInfo> //SchoolDetailResponse -> 기존에 작성한 SchoolInfo 사용
 
     suspend fun getMyStudyGroupList(): ApiState<Unit> //MyStudyGroupListResponse
 

--- a/domain/src/main/java/com/umc/domain/usecase/organization/GetSchoolNameUseCase.kt
+++ b/domain/src/main/java/com/umc/domain/usecase/organization/GetSchoolNameUseCase.kt
@@ -1,0 +1,11 @@
+package com.umc.domain.usecase.organization
+
+import com.umc.domain.repository.OrganizationRepository
+import javax.inject.Inject
+
+class GetSchoolNameUseCase @Inject constructor(
+    private val organizationRepository: OrganizationRepository
+)  {
+    suspend operator fun invoke(schoolId: Long) =
+        organizationRepository.getSchoolDetail(schoolId)
+}

--- a/presentation/src/main/java/com/umc/presentation/ui/home/HomeViewModel.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/home/HomeViewModel.kt
@@ -20,6 +20,8 @@ import com.umc.presentation.base.BaseViewModel
 import com.umc.presentation.base.UiEvent
 import com.umc.presentation.base.UiState
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -143,38 +145,65 @@ class HomeViewModel @Inject constructor(
 
         // 2. 최신기수를 가져오기
         val latestGisu = gisuSummaryList.maxByOrNull { it.gisu }
+        val startGisu = gisuSummaryList.minByOrNull { it.gisu }
 
-        //3. 기본 정보 우선 업데이트
-        updateState {
-            copy(
-                userName = userInfo.name,
-                gisuTag = gisuTags
-            )
-        }
 
-        //4. 최신기수의 날짜 가져오기
-        latestGisu?.let { summary ->
-            viewModelScope.launch {
-                resultResponse(
-                    response = getGisuInfoUseCase(summary.gisuId),
-                    successCallback = { gisuInfo ->
-                        //5. 성공 시 날짜 계산
-                        val (passedDay, userStatus) = getPassedDaysStatus(gisuInfo.startAt, gisuInfo.endAt)
-
-                        updateState {
-                            copy(
-                                userType = userStatus,
-                                growDay = passedDay.toInt(),
-                            )
-                        }
-
-                    },
-                    errorCallback = {
-
-                    }
+        viewModelScope.launch {
+            //3. 기본 정보 우선 업데이트
+            updateState {
+                copy(
+                    userName = userInfo.name,
+                    gisuTag = gisuTags
                 )
             }
 
+            //최신 기수 정보랑 제일 오래된 기수 정보 둘 다 병렬로 실행(YB는 옛날꺼 필요)
+            coroutineScope {
+                val latestResponseDeferred = async {
+                    latestGisu?.let { getGisuInfoUseCase(it.gisuId) }
+                }
+                val startResponseDeferred = async {
+                    startGisu?.let { getGisuInfoUseCase(it.gisuId) }
+                }
+
+                val latestResponse = latestResponseDeferred.await()
+                val startResponse = startResponseDeferred.await()
+
+                if (latestResponse != null && startResponse != null){
+                    //최신 기수 정보를 성공적으로 받아올 때,
+                    resultResponse(
+                        response = latestResponse,
+                        successCallback = { latestGisuInfo ->
+                            //시작 기수 정보 성공적으로 받아올 때
+                            resultResponse(
+                                response = startResponse,
+                                successCallback = { startGisuInfo ->
+                                    //5. 성공 시 날짜 계산
+                                    val (passedDay, userStatus) = getPassedDaysStatus(latestGisuInfo.startAt, latestGisuInfo.endAt,
+                                        startGisuInfo.startAt, startGisuInfo.endAt)
+
+                                    updateState {
+                                        copy(
+                                            userType = userStatus,
+                                            growDay = passedDay.toInt(),
+                                        )
+                                    }
+                                },
+                                errorCallback = {
+                                    //시작 기수 정보 받기 실패
+                                }
+                            )
+
+
+                        },
+                        errorCallback = {
+                            //최신 기수 정보 받기 실패
+                        }
+                    )
+                }
+                
+
+            }
         }
 
         //5. 점수 계산을 통해, 현재 상태 변경하기
@@ -260,21 +289,25 @@ class HomeViewModel @Inject constructor(
     }
 
     //최신 기수 날짜 정보를 통해, OB인지 ACTIVE인지 판단하고, 몇일 지났는지 표현
-    fun getPassedDaysStatus(startDateStr: String, endDateStr: String): Pair<Long, UserType> {
+    fun getPassedDaysStatus(latestStartDateStr: String, latestEndDateStr: String,
+                            oldStartDateStr: String, oldEndDateStr: String): Pair<Long, UserType> {
         val formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd")
-        val startDate = LocalDate.parse(startDateStr, formatter)
-        val endDate = LocalDate.parse(endDateStr, formatter)
+        val latestStartDate = LocalDate.parse(latestStartDateStr, formatter)
+        val latestEndDate = LocalDate.parse(latestEndDateStr, formatter)
+        val oldStartDate = LocalDate.parse(oldStartDateStr, formatter)
+        val oldEndDate = LocalDate.parse(oldEndDateStr, formatter)
+
         val today = LocalDate.now() // 2026-02-16
 
         //오늘이 종료일보다 뒤면 (OB)
-        return if (today.isAfter(endDate)) {
+        return if (today.isAfter(latestEndDate)) {
             //종료일로부터 오늘까지 며칠 지났는지 계산
-            val days = ChronoUnit.DAYS.between(endDate, today)
+            val days = ChronoUnit.DAYS.between(latestEndDate, today)
             Pair(days, UserType.OB)
         } else {
             //오늘이 종료일 이전이거나 종료일 당일인 경우
             //시작일로부터 오늘까지 며칠 지났는지 계산
-            val days = ChronoUnit.DAYS.between(startDate, today)
+            val days = ChronoUnit.DAYS.between(oldStartDate, today)
             Pair(days, UserType.ACTIVE)
         }
     }

--- a/presentation/src/main/java/com/umc/presentation/ui/home/adapter/BottomSheetAddParticipantAdapter.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/home/adapter/BottomSheetAddParticipantAdapter.kt
@@ -25,8 +25,9 @@ class BottomSheetAddParticipantAdapter(
         RecyclerView.ViewHolder(binding.root) {
 
         fun bind(item: ParticipantItem) {
+            val nameType = "${item.name}/${item.nickname}"
             binding.item = item
-            binding.itemTvName.text = item.name
+            binding.itemTvName.text = nameType
             binding.itemTvSchool.text = item.school
 
             binding.itemImvProfile.load(item.profileImage.ifEmpty { null }) {

--- a/presentation/src/main/java/com/umc/presentation/ui/home/adapter/BottomSheetSearchParticipantAdapter.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/home/adapter/BottomSheetSearchParticipantAdapter.kt
@@ -65,8 +65,9 @@ class BottomSheetSearchParticipantAdapter(
     inner class ItemViewHolder(private val binding: ItemBottomSheetParticipantSearchBinding) :
         RecyclerView.ViewHolder(binding.root) {
         fun bind(user: ParticipantItem) {
+            val nameType = "${user.name}/${user.nickname}"
             binding.item = user
-            binding.itemTvName.text = user.name
+            binding.itemTvName.text = nameType
             binding.itemTvSchool.text = user.school
 
             binding.itemImvProfile.load(user.profileImage.ifEmpty { null }) {

--- a/presentation/src/main/java/com/umc/presentation/ui/home/dialog/BottomSheetParticipantDialog.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/home/dialog/BottomSheetParticipantDialog.kt
@@ -1,5 +1,6 @@
 package com.umc.presentation.ui.home.dialog
 
+import android.content.DialogInterface
 import android.net.Uri
 import android.os.Bundle
 import android.util.Log
@@ -62,8 +63,6 @@ class BottomSheetParticipantDialog(
             // 2. 초기 상태를 확장 상태(EXPANDED)로 고정
             behavior.state = BottomSheetBehavior.STATE_EXPANDED
 
-            // 3. 드래그해서 절반으로 접히는 현상 방지 (선택 사항)
-            behavior.skipCollapsed = true
         }
     }
 
@@ -131,11 +130,7 @@ class BottomSheetParticipantDialog(
 
             // 포커스 변경 리스너 등록
             setOnFocusChangedListener { hasFocus ->
-                // 내용이 없고 포커스가 나가면 검색 모드 종료
-                if(hasFocus){
-                    viewModel.setSearchingMode(true)
-                }
-                else if (getText().isEmpty()) {
+                if (getText().isEmpty()) {
                     viewModel.clearSearch()
                 }
             }
@@ -251,6 +246,13 @@ class BottomSheetParticipantDialog(
             // 임시 토스트
             Toast.makeText(requireContext(), "CSV 파일을 읽는 중 오류가 발생했습니다.", Toast.LENGTH_SHORT).show()
         }
+    }
+
+    override fun onDismiss(dialog: DialogInterface) {
+        super.onDismiss(dialog)
+
+        //다이얼로그 닫히면 검색 초기화(선택 화면 보이게 하기)
+        viewModel.clearSearch()
     }
 
 

--- a/presentation/src/main/java/com/umc/presentation/ui/home/dialog/BottomSheetParticipantViewModel.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/home/dialog/BottomSheetParticipantViewModel.kt
@@ -10,6 +10,8 @@ import com.umc.presentation.base.BaseViewModel
 import com.umc.presentation.base.UiEvent
 import com.umc.presentation.base.UiState
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -22,11 +24,23 @@ class BottomSheetParticipantViewModel @Inject constructor(
 ) {
 
     init {
-        searchParticipants("")
+        //searchParticipants("")
     }
+
+    //검색 작업 제어
+    private var searchJob: Job? = null
 
     // 유저 검색 로직
     fun searchParticipants(query: String) {
+        //이전 작업 취소
+        searchJob?.cancel()
+
+        //쿼리가 비어있으면 검색X
+        if (query.isBlank()) {
+            clearSearch()
+            return
+        }
+
         //일단 현재 상태를 반영해서
         updateState {
             copy(
@@ -37,7 +51,10 @@ class BottomSheetParticipantViewModel @Inject constructor(
                 isSearching = query.isNotBlank()
             )
         }
-        fetchParticipants(isNextPage = false)
+        searchJob = viewModelScope.launch {
+            delay(500) //'박ㅇ' 등이 완성되어 '박유수'가 될 때까지 기다림
+            fetchParticipants(isNextPage = false)
+        }
     }
 
 
@@ -117,6 +134,7 @@ class BottomSheetParticipantViewModel @Inject constructor(
 
     //검색 기록을 초기화하하고 중지하는 함수
     fun clearSearch() {
+        searchJob?.cancel()
         updateState {
             copy(
                 searchResults = emptyList(), // 혹은 초기 리스트(allChallengers)

--- a/presentation/src/main/java/com/umc/presentation/ui/mypage/MypageFragment.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/mypage/MypageFragment.kt
@@ -23,6 +23,7 @@ import android.provider.Settings
 import com.kakao.sdk.talk.TalkApiClient
 import com.kakao.sdk.user.UserApiClient
 import com.umc.presentation.MainGraphDirections
+import com.umc.presentation.ui.mypage.dialog.BottomSheetAddCodeDialog
 
 @AndroidEntryPoint
 class MypageFragment : BaseFragment<FragmentMypageBinding, MypageFragmentUiState, MypageFragmentEvent, MypageViewModel>(
@@ -136,6 +137,11 @@ class MypageFragment : BaseFragment<FragmentMypageBinding, MypageFragmentUiState
                     showType = "MYSCRAP"
                 )
                 findNavController().navigate(action)
+            }
+
+            is MypageFragmentEvent.NavigateToAddActivity -> {
+                val dialog = BottomSheetAddCodeDialog()
+                dialog.show(parentFragmentManager, "BottomSheetAddCodeDialog")
             }
 
 

--- a/presentation/src/main/java/com/umc/presentation/ui/mypage/MypageViewModel.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/mypage/MypageViewModel.kt
@@ -132,6 +132,10 @@ class MypageViewModel @Inject constructor(
         emitEvent(MypageFragmentEvent.NavigateToScrap)
     }
 
+    fun navigateToAddActivity(){
+        emitEvent(MypageFragmentEvent.NavigateToAddActivity)
+    }
+
 
     fun navigateToAssistUmc(){
         emitEvent(MypageFragmentEvent.NavigateToAssistUmc(uiState.value.kakaoInquireChannelId))
@@ -268,6 +272,8 @@ sealed interface MypageFragmentEvent : UiEvent {
     object NavigateToMypost : MypageFragmentEvent //내가 쓴 글
     object NavigateToMyComment : MypageFragmentEvent //내가 쓴 댓글
     object NavigateToScrap : MypageFragmentEvent //스크랩
+
+    object NavigateToAddActivity : MypageFragmentEvent //활동 추가
     
     data class NavigateToAssistUmc(val channelId: String) : MypageFragmentEvent // UMC 문의
 

--- a/presentation/src/main/java/com/umc/presentation/ui/mypage/dialog/BottomSheetAddCodeDialog.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/mypage/dialog/BottomSheetAddCodeDialog.kt
@@ -1,0 +1,107 @@
+package com.umc.presentation.ui.mypage.dialog
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Toast
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import com.google.android.material.bottomsheet.BottomSheetBehavior
+import com.google.android.material.bottomsheet.BottomSheetDialog
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import com.umc.domain.model.home.ParticipantItem
+import com.umc.presentation.databinding.LayoutBottomSheetAddCodeBinding
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+@AndroidEntryPoint
+class BottomSheetAddCodeDialog() : BottomSheetDialogFragment() {
+
+    private var _binding: LayoutBottomSheetAddCodeBinding? = null
+    private val binding get() = _binding!!
+
+    private val viewModel: BottomSheetAddCodeViewModel by viewModels()
+
+    override fun onStart() {
+        super.onStart()
+
+
+        // 다이얼로그의 내부 뷰(design_bottom_sheet)를 찾아 높이를 설정
+        (dialog as? BottomSheetDialog)?.findViewById<View>(com.google.android.material.R.id.design_bottom_sheet)?.let { bottomSheet ->
+            val behavior = BottomSheetBehavior.from(bottomSheet)
+
+            // 1. 레이아웃 파라미터의 높이를 화면 전체의 80%로 설정
+            val layoutParams = bottomSheet.layoutParams
+            layoutParams.height = (resources.displayMetrics.heightPixels * 0.8).toInt()
+            bottomSheet.layoutParams = layoutParams
+
+            // 2. 초기 상태를 확장 상태(EXPANDED)로 고정
+            behavior.state = BottomSheetBehavior.STATE_EXPANDED
+
+        }
+
+
+    }
+
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = LayoutBottomSheetAddCodeBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        binding.lifecycleOwner = viewLifecycleOwner
+        binding.vm = viewModel
+
+        repeatOnStarted(viewLifecycleOwner) {
+            launch {
+                viewModel.uiEvent.collect { event ->
+                    handleEvent(event)
+                }
+            }
+        }
+
+
+
+    }
+
+    private fun handleEvent(event: BottomSheetAddCodeEvent) {
+        when (event) {
+            is BottomSheetAddCodeEvent.Confirm -> {
+                Toast.makeText(requireContext(), "활동기록이 추가되었습니다.", Toast.LENGTH_SHORT).show()
+                dismiss()
+            }
+
+            is BottomSheetAddCodeEvent.ShowToast -> {
+                Toast.makeText(requireContext(), event.message, Toast.LENGTH_SHORT).show()
+            }
+        }
+    }
+
+    protected fun LifecycleOwner.repeatOnStarted(
+        viewLifecycleOwner: LifecycleOwner,
+        block: suspend CoroutineScope.() -> Unit,
+    ) {
+        viewLifecycleOwner.lifecycleScope.launch {
+            lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED, block)
+        }
+    }
+
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
+}

--- a/presentation/src/main/java/com/umc/presentation/ui/mypage/dialog/BottomSheetAddCodeViewModel.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/mypage/dialog/BottomSheetAddCodeViewModel.kt
@@ -1,0 +1,56 @@
+package com.umc.presentation.ui.mypage.dialog
+
+import android.util.Log
+import androidx.lifecycle.viewModelScope
+import com.umc.domain.model.home.ParticipantItem
+import com.umc.domain.model.request.challenger.ChallengerRecordMemberRequest
+import com.umc.domain.usecase.challenger.AddChallengerRecordMemberUseCase
+import com.umc.presentation.base.BaseViewModel
+import com.umc.presentation.base.UiEvent
+import com.umc.presentation.base.UiState
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+
+@HiltViewModel
+class BottomSheetAddCodeViewModel @Inject constructor(
+    private val addChallengerRecordMemberUseCase: AddChallengerRecordMemberUseCase,
+) : BaseViewModel<BottomSheetAddCodeUiState, BottomSheetAddCodeEvent>(
+    BottomSheetAddCodeUiState()
+) {
+
+    fun onCodeChanged(code: String) {
+        updateState { copy(code = code) }
+    }
+
+    fun register() {
+        viewModelScope.launch {
+            val request = ChallengerRecordMemberRequest(
+                code = uiState.value.code,
+            )
+            Log.d("log_mypage", "register: $request")
+            resultResponse(
+                response = addChallengerRecordMemberUseCase(request),
+                successCallback = {
+                    emitEvent(BottomSheetAddCodeEvent.Confirm)
+                },
+                errorCallback = { failState ->
+                    emitEvent(BottomSheetAddCodeEvent.ShowToast(failState.message))
+                }
+            )
+        }
+    }
+
+}
+
+
+data class BottomSheetAddCodeUiState(
+    val code: String = "",
+
+    ) : UiState
+
+sealed interface BottomSheetAddCodeEvent : UiEvent {
+    object Confirm : BottomSheetAddCodeEvent
+    data class ShowToast(val message: String) : BottomSheetAddCodeEvent
+}

--- a/presentation/src/main/java/com/umc/presentation/ui/mypage/profile/ProfileViewModel.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/mypage/profile/ProfileViewModel.kt
@@ -15,11 +15,15 @@ import com.umc.domain.model.request.member.UpdateLinkRequest
 import com.umc.domain.usecase.appDataStore.GetUserInfoUseCase
 import com.umc.domain.usecase.member.UpdateMyLinkUseCase
 import com.umc.domain.usecase.member.UpdateMyProfileUseCase
+import com.umc.domain.usecase.organization.GetSchoolNameUseCase
 import com.umc.domain.usecase.storage.UploadFileUseCase
 import com.umc.presentation.base.BaseViewModel
 import com.umc.presentation.base.UiEvent
 import com.umc.presentation.base.UiState
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -30,6 +34,7 @@ class ProfileViewModel @Inject constructor(
     private val uploadFileUseCase: UploadFileUseCase, //파일 업로드 하기(이미지 업로드)
     private val updateMyProfileUseCase: UpdateMyProfileUseCase, //프로필 정보 업데이트
     private val updateMyLinkUseCase: UpdateMyLinkUseCase, //링크 정보 업데이트
+    private val getSchoolNameUseCase: GetSchoolNameUseCase, //학교 이름 가져오기
     ) : BaseViewModel<ProfileFragmentUiState, ProfileFragmentEvent>(
     ProfileFragmentUiState()){
 
@@ -54,74 +59,70 @@ class ProfileViewModel @Inject constructor(
 
     //유저 정보를 통해 활동 이력 및 기수파트 작성
     fun settingUserInfoToUI(userInfo: UserInfo){
-        val gisuSummaryList = userInfo.getGisuSummaryList()
+        
+        viewModelScope.launch {
+            //기수 정보 리스트 가져오기
+            val gisuSummaryList = userInfo.getGisuSummaryList()
 
-        //최종 리스트
-        val activeHistory = mutableListOf<UserActiveItem>()
+            //api 호출 시 coroutineScope를 사용하여 async를 호출 - 다 끝날때까지 기달
+            val finalActiveHistory = coroutineScope {
+                gisuSummaryList.flatMap { summary ->
+                    val generationText = "${summary.gisu}기"
 
-        Log.d("log_mypage", "날것: $gisuSummaryList")
-
-        //gisuSummaryList를 돌면서 만들기
-        gisuSummaryList.forEach { summary->
-            //1. 기수 별 분류 (여기에 roles/ challengers)
-            val generationText = "${summary.gisu}기"
-
-            //2. 운영진 기록이 있으면 싹다 만들기
-            summary.fromRoles.forEach { roleItem ->
-                    //담당 파트가 있으면 (웹 파트장)
-                    val item = if (roleItem.responsiblePart != null) {
-                        UserActiveItem(
-                            generation = generationText,
-                            partName = "${roleItem.responsiblePart} Part",
-                            position = UserChallengerRole.from(roleItem.role).displayName ?: roleItem.role
-                        )
+                    //운영진 기록
+                    val roleJobs = summary.fromRoles.map { roleItem ->
+                        async {
+                            //파트가 있는 경우 (ex. 안드로이드 파트장)
+                            if (roleItem.responsiblePart != null) {
+                                UserActiveItem(
+                                    generation = generationText,
+                                    partName = "${roleItem.responsiblePart} Part",
+                                    position = UserChallengerRole.from(roleItem.role).displayName ?: roleItem.role
+                                )
+                            } 
+                            //그 외 (교내 회장)
+                            else {
+                                //들어갈 값
+                                var itemResult: UserActiveItem? = null
+                                resultResponse(
+                                    response = getSchoolNameUseCase(roleItem.organizationId),
+                                    //학교 불러오기 성공이면, 학교 이름을 가져오기
+                                    successCallback = { schoolInfo ->
+                                        val label = UserChallengerRole.from(roleItem.role).displayName ?: roleItem.role
+                                        itemResult = UserActiveItem(generationText, "${schoolInfo.schoolName} $label",label, )
+                                    },
+                                    //못 불러오면 그대로 넣기
+                                    errorCallback = {
+                                        val label = UserChallengerRole.from(roleItem.role).displayName ?: roleItem.role
+                                        itemResult = UserActiveItem(generationText, label, label)
+                                    }
+                                )
+                                itemResult!!
+                            }
+                        }
                     }
-                    //담당 파트가 없으면 (총괄)
-                    else {
-                        val roleLabel =
-                            //label 없으면 enum 이름 그대로 쓰자.
-                            UserChallengerRole.from(roleItem.role).displayName ?: roleItem.role
-                        UserActiveItem(
-                            generation = generationText,
-                            partName = roleLabel,
-                            position = roleLabel
-                        )
-                    }
 
-                    activeHistory.add(item)
-                }
+                    //챌린저 기록
+                    val recordJobs = summary.fromRecords
+                        .filter { it.responsiblePart != "ADMIN" }
+                        .map { recordItem ->
+                            async {
+                                UserActiveItem(
+                                    generation = generationText,
+                                    partName = "${recordItem.responsiblePart} Part",
+                                    position = "챌린저"
+                                )
+                            }
+                        }
 
-            //3. 챌린저 기록이 있으면 싹 다 만들기
-            summary.fromRecords.forEach { recordItem ->
-                //챌린저 중 admin이 있을 경우에는 제거
-                if(recordItem.responsiblePart != "ADMIN") {
-                    val item = UserActiveItem(
-                        generation = generationText,
-                        partName = "${recordItem.responsiblePart} Part",
-                        position = "챌린저"
-                    )
-                    activeHistory.add(item)
-                    }
+                    roleJobs + recordJobs
+                }.awaitAll() // 모든 async 작업이 완료될 때까지 기다림
             }
-        }
 
-        //최신 파트(기수/파트) - 이거는 role 우선
-        /*
-        val latestHistory = activeHistory.firstOrNull()
-        val latestPartAndGisu = latestHistory?.let {
-            "${it.generation}/${it.partName.replace(" Part", "")}"
-        } ?: "정보 없음"
-
-         */
-
-        Log.d("log_mypage", "변환 결과: $activeHistory")
-
-        //이 정보를 저장
-        updateState {
-            copy(
-                myActiveHistory = activeHistory,
-
-            )
+            //모든 데이터가 수집된 후 UI 업데이트
+            updateState {
+                copy(myActiveHistory = finalActiveHistory)
+            }
         }
 
 

--- a/presentation/src/main/java/com/umc/presentation/ui/mypage/profile/ProfileViewModel.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/mypage/profile/ProfileViewModel.kt
@@ -93,20 +93,26 @@ class ProfileViewModel @Inject constructor(
 
             //3. 챌린저 기록이 있으면 싹 다 만들기
             summary.fromRecords.forEach { recordItem ->
-                val item = UserActiveItem(
-                    generation = generationText,
-                    partName = "${recordItem.responsiblePart} Part",
-                    position = "챌린저"
-                )
-                activeHistory.add(item)
+                //챌린저 중 admin이 있을 경우에는 제거
+                if(recordItem.responsiblePart != "ADMIN") {
+                    val item = UserActiveItem(
+                        generation = generationText,
+                        partName = "${recordItem.responsiblePart} Part",
+                        position = "챌린저"
+                    )
+                    activeHistory.add(item)
+                    }
             }
         }
 
         //최신 파트(기수/파트) - 이거는 role 우선
+        /*
         val latestHistory = activeHistory.firstOrNull()
         val latestPartAndGisu = latestHistory?.let {
             "${it.generation}/${it.partName.replace(" Part", "")}"
         } ?: "정보 없음"
+
+         */
 
         Log.d("log_mypage", "변환 결과: $activeHistory")
 
@@ -114,7 +120,7 @@ class ProfileViewModel @Inject constructor(
         updateState {
             copy(
                 myActiveHistory = activeHistory,
-                myPart = latestPartAndGisu
+
             )
         }
 
@@ -225,7 +231,6 @@ class ProfileViewModel @Inject constructor(
 data class ProfileFragmentUiState(
     //유저 정보 (고정)
     val loginType: LoginType = LoginType.KAKAO,
-    val myPart: String = "",
     val userInfo : UserInfo = UserInfo(),
 
 

--- a/presentation/src/main/java/com/umc/presentation/ui/mypage/profile/ProfileViewModel.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/mypage/profile/ProfileViewModel.kt
@@ -59,6 +59,8 @@ class ProfileViewModel @Inject constructor(
         //최종 리스트
         val activeHistory = mutableListOf<UserActiveItem>()
 
+        Log.d("log_mypage", "날것: $gisuSummaryList")
+
         //gisuSummaryList를 돌면서 만들기
         gisuSummaryList.forEach { summary->
             //1. 기수 별 분류 (여기에 roles/ challengers)
@@ -71,7 +73,7 @@ class ProfileViewModel @Inject constructor(
                         UserActiveItem(
                             generation = generationText,
                             partName = "${roleItem.responsiblePart} Part",
-                            position = roleItem.role
+                            position = UserChallengerRole.from(roleItem.role).displayName ?: roleItem.role
                         )
                     }
                     //담당 파트가 없으면 (총괄)
@@ -105,6 +107,8 @@ class ProfileViewModel @Inject constructor(
         val latestPartAndGisu = latestHistory?.let {
             "${it.generation}/${it.partName.replace(" Part", "")}"
         } ?: "정보 없음"
+
+        Log.d("log_mypage", "변환 결과: $activeHistory")
 
         //이 정보를 저장
         updateState {

--- a/presentation/src/main/res/layout/fragment_mypage.xml
+++ b/presentation/src/main/res/layout/fragment_mypage.xml
@@ -696,6 +696,39 @@
                     android:src="@drawable/ic_arrow_next"
                     app:tint="@color/neutral400" />
             </LinearLayout>
+
+            <!--내 활동 추가-->
+            <LinearLayout
+                android:id="@+id/mypage_btn_addactivity"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="?attr/selectableItemBackground"
+                android:gravity="center_vertical"
+                android:onClick="@{() -> vm.navigateToAddActivity()}"
+                android:padding="12dp">
+
+                <ImageView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:src="@drawable/ic_add"
+                    app:tint="@color/neutral800" />
+
+                <TextView
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="12dp"
+                    android:layout_weight="1"
+                    android:text="@string/mypage_addactivity"
+                    android:textAppearance="@style/Body"
+                    android:textColor="@color/neutral800" />
+
+                <ImageView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:src="@drawable/ic_arrow_next"
+                    app:tint="@color/neutral400" />
+            </LinearLayout>
+
         </LinearLayout>
         </com.google.android.material.card.MaterialCardView>
 

--- a/presentation/src/main/res/layout/fragment_profile.xml
+++ b/presentation/src/main/res/layout/fragment_profile.xml
@@ -274,7 +274,7 @@
             app:strokeWidth="1dp"
             app:strokeColor="@color/neutral300"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toStartOf="@id/profile_guideline_divide"
+            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toBottomOf="@id/profile_tv_title_school">
 
         <TextView
@@ -290,50 +290,6 @@
 
         </com.google.android.material.card.MaterialCardView>
 
-        <!--기수/파트-->
-        <TextView
-            android:id="@+id/profile_tv_title_part"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:textAppearance="@style/HeadlineBold"
-            android:textColor="@color/neutral800"
-            android:text="@string/profile_part"
-            android:gravity="start"
-            android:layout_marginStart="8dp"
-            android:layout_marginTop="24dp"
-            app:layout_constraintTop_toBottomOf="@id/profile_cdv_nickname"
-            app:layout_constraintStart_toEndOf="@id/profile_guideline_divide"
-            app:layout_constraintEnd_toEndOf="parent"
-            />
-
-        <com.google.android.material.card.MaterialCardView
-            android:id="@+id/profile_cdv_part"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="8dp"
-            android:layout_marginStart="8dp"
-            android:clickable="false"
-            app:cardBackgroundColor="@color/neutral100"
-            app:cardCornerRadius="8dp"
-            app:cardElevation="0dp"
-            app:strokeWidth="1dp"
-            app:strokeColor="@color/neutral300"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toEndOf="@id/profile_guideline_divide"
-            app:layout_constraintTop_toBottomOf="@id/profile_tv_title_part">
-
-            <TextView
-                android:id="@+id/profile_tv_part"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:paddingHorizontal="16dp"
-                android:paddingVertical="14dp"
-                android:gravity="start|center_vertical"
-                android:text="@{vm.uiState.myPart}"
-                android:textAppearance="@style/Callout"
-                android:textColor="@color/neutral600" />
-
-        </com.google.android.material.card.MaterialCardView>
 
 
         <!--활동 이력-->

--- a/presentation/src/main/res/layout/item_bottom_sheet_category_plan.xml
+++ b/presentation/src/main/res/layout/item_bottom_sheet_category_plan.xml
@@ -36,7 +36,6 @@
             android:id="@+id/cb_category"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:buttonTint="@color/primary500"
             android:checked="@{item.isChecked}"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"

--- a/presentation/src/main/res/layout/layout_bottom_sheet_add_code.xml
+++ b/presentation/src/main/res/layout/layout_bottom_sheet_add_code.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    >
+
+    <data>
+        <variable
+            name="vm"
+            type="com.umc.presentation.ui.mypage.dialog.BottomSheetAddCodeViewModel" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/layout_root"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@drawable/bg_bottom_sheet_neutral000_radius28"
+        android:paddingHorizontal="16dp"
+        android:paddingBottom="24dp"
+        >
+
+        <com.google.android.material.card.MaterialCardView
+            android:id="@+id/view_handle"
+            android:layout_width="40dp"
+            android:layout_height="4dp"
+            android:layout_marginTop="12dp"
+            android:background="@color/neutral600"
+            app:cardBackgroundColor="@color/neutral600"
+            app:cornerRadius="100dp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/tv_title"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="28dp"
+            android:gravity="start"
+            android:text="추가할 활동의 인증코드를 입력해주세요."
+            android:textAppearance="@style/Title3Bold"
+            android:textColor="@color/neutral800"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toStartOf="@id/btn_upload_csv"
+            app:layout_constraintTop_toBottomOf="@id/view_handle" />
+
+        <TextView
+            android:id="@+id/tv_title_code"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="40dp"
+            android:text="인증코드"
+            android:textAppearance="@style/HeadlineBold"
+            android:textColor="@color/neutral800"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_title"
+            />
+
+        <com.umc.presentation.component.UTextField
+            android:id="@+id/text_field_code"
+            android:layout_width="match_parent"
+            android:layout_height="52dp"
+            android:layout_marginTop="16dp"
+            app:backgroundColor="@color/neutral000"
+            app:cornerRadius="8dp"
+            android:maxLength="6"
+            app:focusStrokeColor="@color/primary500"
+            app:strokeColor="@color/neutral300"
+            app:onTextChanged="@{vm::onCodeChanged}"
+            app:placeholderText="6자리 코드를 입력하세요"
+            app:strokeWidth="1dp"
+            app:text="@{vm.uiState.code}"
+            app:textAppearance="@style/Body"
+            app:textColor="@color/neutral800"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_title_code"
+            />
+
+        <com.umc.presentation.component.UButton
+            android:id="@+id/btn_confirm"
+            android:layout_width="0dp"
+            android:layout_height="52dp"
+            android:visibility="visible"
+            android:onClick="@{()->vm.register()}"
+            android:clickable="true"
+            app:cardBackgroundColor="@color/primary500"
+            app:pressedColor="@color/primary700"
+            app:borderWidth="0dp"
+            app:text="추가하기"
+            app:textAppearance="@style/SubheadlineBold"
+            app:textColor="@color/neutral000"
+            app:buttonElevation="0"
+            app:contentPaddingBottom="4dp"
+            app:contentPaddingTop="4dp"
+            app:contentPaddingLeft="8dp"
+            app:contentPaddingRight="8dp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            />
+
+
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</layout>

--- a/presentation/src/main/res/layout/layout_bottom_sheet_participant_add.xml
+++ b/presentation/src/main/res/layout/layout_bottom_sheet_participant_add.xml
@@ -133,22 +133,25 @@
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/layout_added"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
+            android:layout_height="0dp"
             android:layout_marginTop="24dp"
             android:visibility="@{vm.uiState.isSearching ? View.GONE : View.VISIBLE}"
             app:layout_constraintTop_toBottomOf="@id/searchbar_participant"
+            app:layout_constraintBottom_toBottomOf="parent"
             >
 
 
             <LinearLayout
                 android:id="@+id/layout_empty_state"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
+                android:layout_height="0dp"
                 android:gravity="center"
                 android:orientation="vertical"
                 android:layout_marginTop="40dp"
                 android:visibility="@{vm.uiState.isSelectedParticipant ? View.GONE : View.VISIBLE}"
-                app:layout_constraintTop_toTopOf="parent">
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintBottom_toBottomOf="parent"
+                >
 
                 <ImageView
                     android:layout_width="48dp"
@@ -167,7 +170,7 @@
             <androidx.recyclerview.widget.RecyclerView
                 android:id="@+id/rcv_added"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
+                android:layout_height="0dp"
                 android:layout_marginTop="16dp"
                 android:nestedScrollingEnabled="true"
                 android:overScrollMode="never"
@@ -186,17 +189,21 @@
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/layout_search_result"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
+            android:layout_height="0dp"
             android:layout_marginTop="24dp"
             android:visibility="@{vm.uiState.isSearching ? View.VISIBLE : View.GONE}"
             app:layout_constraintTop_toBottomOf="@id/searchbar_participant"
+            app:layout_constraintBottom_toBottomOf="parent"
             >
 
             <androidx.recyclerview.widget.RecyclerView
                 android:id="@+id/rcv_search_result"
                 android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />
+                android:layout_height="0dp"
+                app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintBottom_toBottomOf="parent"
+                />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -47,6 +47,7 @@
     <string name="mypage_mypost">내가 쓴 글</string>
     <string name="mypage_mycomment">댓글 단 글</string>
     <string name="mypage_myscrap">스크랩</string>
+    <string name="mypage_addactivity">내 활동 추가</string>
     <string name="mypage_setting_notice">알림 설정</string>
     <string name="mypage_setting_location">위치 설정</string>
     <string name="mypage_social">소셜 연동</string>


### PR DESCRIPTION
## #️⃣ 이슈 번호

> 관련된 이슈 번호를 적어주세요.\
> Close #146 

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 요약해주세요.

- 마이페이지 -> 내 정보 상세 화면 QA 반영
  - 기수/파트 출력 영역 삭제(이미 활동 내역에서 보여주기 때문에 중복)
  - 운영진 기록을 출력할 때, enum의 displayName이 아닌 enum 자체를 출력하는 버그 수정
  - 운영진 기록에서 교내 회장 등의 정보가 주어질 때, 학교 정보 조회 usecase를 이용하여, 같이 출력하도록 로직 개선

- 챌린저 추가 및 태그 다이얼로그 QA 반영
  - texffeild에 내용이 없으면, 추가된 유저를 출력하도록 변경
  - 스크롤 개선을 통해, 추가된 유저 수에 상관없이 스크롤 되도록 변경
  - 태그 다이얼로그에서 체크박스가 체크표시 되도록 수정
 
- 홈 페이지 날짜 QA 반영
  - 최신 기수 뿐 아니라 시작 기수의 시작/종료 날짜를 같이 파싱하여, OB의 경우 최신 기수를 기준으로 D-Day를 계산하고, YB의 경우 시작 기수를 기준으로 D-Day를 계산하도록 로직 수정

- 마이페이지 -> 내활동 -> 챌린저 코드 추가
  - 내 활동에 `내 활동 추가` 탭을 신설
  - 해당 탭 터치 시, 코드를 입력받는 다이얼로그가 생성 (로직은 SignUpFailCode 쪽을 차용) 


## 📸 스크린샷 (선택 사항)
| 마이페이지 내 활동기록 UI 개선 | 태그 다이얼로그 체크 개선 |
| :---: | :---: |
| ![KakaoTalk_20260307_003654879](https://github.com/user-attachments/assets/09c98ab0-1d7a-4300-b3ea-22b0cf5b6cd4) | ![KakaoTalk_20260307_003655271](https://github.com/user-attachments/assets/5ec71a70-c328-4637-8c44-403012a8c790) |

## 시연 영상

**챌린저 코드 추가**

https://github.com/user-attachments/assets/426c6d09-425d-460a-9966-ab4594b7b7ea



**챌린저 추가 다이얼로그 개선**

https://github.com/user-attachments/assets/96c38e5b-87a0-438f-af32-a115199215f6




## 🚩 리뷰 요구사항
> 리뷰어가 중점적으로 봐주었으면 하는 부분이 있다면 작성해주세요.

## 🏁 체크리스트
- [x] 코딩 컨벤션을 준수했나요?
- [x] 불필요한 로그나 주석을 제거했나요?
- [x] 머지 대상 브랜치(Base branch)가 올바른가요?
