### PR TITLE
[Fix/#148] 일정 생성 QA 반영

### DIFF
--- a/presentation/src/main/java/com/umc/presentation/ui/home/PlanAddViewModel.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/home/PlanAddViewModel.kt
@@ -217,7 +217,9 @@ constructor(
             }
 
 
-        val participantIds = state.selectedParticipants.map { it.id }
+        //내 ID도 추가(만약 이미 있으면 중복 체거)
+        val participantIds = (state.selectedParticipants.map { it.id } + state.myInfo.id).distinct()
+
 
 
         viewModelScope.launch {

--- a/presentation/src/main/java/com/umc/presentation/ui/home/dialog/BottomSheetParticipantViewModel.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/home/dialog/BottomSheetParticipantViewModel.kt
@@ -75,7 +75,7 @@ class BottomSheetParticipantViewModel @Inject constructor(
             resultResponse(
                 response = searchChallengerScheduleUseCase(
                     cursor = cursor,
-                    size = 20,
+                    size = 50,
                     name = state.searchQuery.ifBlank { null } // 빈 검색어는 null로 그 외는 searchParticipant에서 가져온 쿼리로
                 ),
                 successCallback = { response ->


### PR DESCRIPTION
## #️⃣ 이슈 번호

> 관련된 이슈 번호를 적어주세요.\
> Close #148

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 요약해주세요.

- 일정 생성 시 작성한 유저도 참여 인원에 포함되도록 수정
- 챌린저 추가 다이얼로그 유저 fetch 시 인원 20 -> 50명으로 증가
  - 기종에 따라 무한스크롤이 진행되는 문제 확인 (인원 추가로 막음)

## 📸 스크린샷 (선택 사항)
| 설명 | 이미지 |
| :---: | :---: |
|  |  |

## 🚩 리뷰 요구사항
> 리뷰어가 중점적으로 봐주었으면 하는 부분이 있다면 작성해주세요.

## 🏁 체크리스트
- [ ] 코딩 컨벤션을 준수했나요?
- [ ] 불필요한 로그나 주석을 제거했나요?
- [ ] 머지 대상 브랜치(Base branch)가 올바른가요?
