### PR TITLE
[Feat/#150] 커뮤니티 및 일정 QA

### DIFF
--- a/data/src/main/java/com/umc/data/response/community/PostDetailResponse.kt
+++ b/data/src/main/java/com/umc/data/response/community/PostDetailResponse.kt
@@ -13,8 +13,10 @@ data class PostDetailResponse(
     @SerializedName("title") val title: String,                // 게시글 제목
     @SerializedName("content") val content: String,            // 게시글 본문
     @SerializedName("category") val category: String,          // 게시글 카테고리
-    @SerializedName("authorId")val authorId: Long,             // 게시글 작성자 ID
-    @SerializedName("authorName")val authorName: String,       // 게시글 작성자 이름
+    @SerializedName("authorChallengerId")val authorChallengerId: Long?,
+    @SerializedName("authorMemberId") val authorMemberId: Long?, // 게시글 작성자 ID
+    @SerializedName("authorName")val authorName: String?,       // 게시글 작성자 이름
+    @SerializedName("authorNickname") val authorNickName: String?,
     @SerializedName("authorProfileImage") val authorProfileImage: String?, // 게시글 작성자 프로필 이미지
     @SerializedName("authorPart") val authorPart: String,           // 게시글 작성자 유저파트
     @SerializedName("lightningInfo") val lightningInfo: LightningInfoResponse?, // 번개 모임 상세 정보 (일반글은 null)
@@ -44,8 +46,10 @@ data class PostDetailResponse(
                 } catch (e: Exception) {
                     CommunityCategoryType.FREE
                 },
-                username = this.authorName,
-                userId = this.authorId,
+                username = this.authorName ?: "알 수 없음",
+                userNickName = this.authorNickName ?: "",
+                userId = this.authorChallengerId ?: -1L,
+                userMemberId = this.authorMemberId ?: -1L,
                 writeTime = formatTime,
                 likes = this.likeCount,
                 comments = this.commentCount,

--- a/data/src/main/java/com/umc/data/response/community/PostDetailResponse.kt
+++ b/data/src/main/java/com/umc/data/response/community/PostDetailResponse.kt
@@ -46,7 +46,7 @@ data class PostDetailResponse(
                 } catch (e: Exception) {
                     CommunityCategoryType.FREE
                 },
-                username = this.authorName ?: "알 수 없음",
+                username = this.authorName ?: "",
                 userNickName = this.authorNickName ?: "",
                 userId = this.authorChallengerId ?: -1L,
                 userMemberId = this.authorMemberId ?: -1L,

--- a/data/src/main/java/com/umc/data/response/community/PostSearchSummaryResponse.kt
+++ b/data/src/main/java/com/umc/data/response/community/PostSearchSummaryResponse.kt
@@ -12,7 +12,10 @@ data class PostSearchSummaryResponse (
     @SerializedName("title") val title: String,
     @SerializedName("content") val content: String,
     @SerializedName("category") val category: String,
-    @SerializedName("authorName") val authorName: String,
+    @SerializedName("authorChallengerId") val authorChallengerId: Long?,             // 게시글 작성자 ID
+    @SerializedName("authorMemberId") val authorMemberId: Long?,             // 게시글 작성자 ID
+    @SerializedName("authorName") val authorName: String?,       // 게시글 작성자 이름
+    @SerializedName("authorNickname") val authorNickName: String?,
     @SerializedName("likeCount") val likeCount: Int,
     @SerializedName("commentCount") val commentCount: Int,
     @SerializedName("authorPart") val authorPart: String,
@@ -33,7 +36,10 @@ data class PostSearchSummaryResponse (
                     CommunityCategoryType.FREE
                 },
                 // 일부는 직접 (추후 서버 요청)
-                username = this.authorName,
+                username = this.authorName ?: "",
+                userNickName = this.authorNickName ?: "",
+                userId = this.authorChallengerId ?: -1L,
+                userMemberId = this.authorMemberId ?: -1L,
                 writeTime = "${writeDay} ${writeTime}", // TODO: 서버 응답에 생성일자가 추가되면 파싱 로직 적용
                 likes = likeCount,
                 comments = commentCount,

--- a/data/src/main/java/com/umc/data/response/community/PostSummaryResponse.kt
+++ b/data/src/main/java/com/umc/data/response/community/PostSummaryResponse.kt
@@ -13,8 +13,10 @@ data class PostSummaryResponse(
     @SerializedName("title") val title: String,                // 게시글 제목
     @SerializedName("content") val content: String,            // 게시글 본문
     @SerializedName("category") val category: String,          // 게시글 카테고리
-    @SerializedName("authorId")val authorId: Long,             // 게시글 작성자 ID
-    @SerializedName("authorName")val authorName: String,       // 게시글 작성자 이름
+    @SerializedName("authorChallengerId") val authorChallengerId: Long?,             // 게시글 작성자 ID
+    @SerializedName("authorMemberId") val authorMemberId: Long?,             // 게시글 작성자 ID
+    @SerializedName("authorName") val authorName: String?,       // 게시글 작성자 이름
+    @SerializedName("authorNickname") val authorNickName: String?,
     @SerializedName("authorProfileImage")val authorProfileImage: String?,       // 게시글 작성자 프로필 이미지
     @SerializedName("createdAt") val createdAt: String?,        // 게시글 생성 시간
     @SerializedName("commentCount") val commentCount: Int,      // 댓글 수
@@ -41,8 +43,10 @@ data class PostSummaryResponse(
                 } catch (e: Exception) {
                     CommunityCategoryType.FREE
                 },
-                userId = this.authorId,
-                username = this.authorName,
+                userId = this.authorChallengerId ?: -1L,
+                userMemberId = this.authorMemberId ?: -1L,
+                username = this.authorName ?: "",
+                userNickName = this.authorNickName ?: "",
                 userProfileImage = this.authorProfileImage ?: "",
                 writeTime = formatTime,
                 likes = this.likeCount,

--- a/domain/src/main/java/com/umc/domain/model/community/ContentItem.kt
+++ b/domain/src/main/java/com/umc/domain/model/community/ContentItem.kt
@@ -10,8 +10,10 @@ data class ContentItem (
     val postId: Long = -1L,
     val title : String,                     //제목
     val category : CommunityCategoryType,   //카테고리 타입
-    val userId : Long = -1L,                //작성자 ID
-    val username : String = "",             //작성자 
+    val userId : Long = -1L,                //작성자 ID(challengerId)
+    val userMemberId : Long = -1L,          //작성자 MEMBERID
+    val username : String = "",             //작성자
+    val userNickName : String = "",         //작성자 닉네임
     val userProfileImage: String = "",      //작싱자 아이콘
     val writeTime: String = "",             //작성 시간
     val likes : Int = 0,                    //좋아요 수

--- a/domain/src/main/java/com/umc/domain/model/enums/CategoryType.kt
+++ b/domain/src/main/java/com/umc/domain/model/enums/CategoryType.kt
@@ -14,4 +14,5 @@ enum class CategoryType(val label: String) {
     STUDY("스터디"),
     HACKATHON("해커톤"),
     WORKSHOP("워크샵"),
+    AFTER_PARTY("뒷풀이")
 }

--- a/presentation/src/main/java/com/umc/presentation/ui/community/detail/PostDetailViewModel.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/community/detail/PostDetailViewModel.kt
@@ -132,7 +132,7 @@ constructor(
             resultResponse(
                 response = commentsResult,
                 successCallback = {
-                    fetchedComments = it
+                    fetchedComments = it.sortedBy { it.createdAt }
                 },
                 errorCallback = {
 
@@ -190,8 +190,9 @@ constructor(
             resultResponse(
                 response = getCommunityPostCommentUseCase(postId),
                 successCallback = { updatedComments ->
+                    val sortedComments = updatedComments.sortedBy { it.createdAt }
                     // 최신 댓글 목록으로 UI 재조립
-                    rebuildDetailList(uiState.value.nowContent, updatedComments)
+                    rebuildDetailList(uiState.value.nowContent, sortedComments)
                 }
             )
         }

--- a/presentation/src/main/java/com/umc/presentation/ui/home/HomeViewModel.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/home/HomeViewModel.kt
@@ -153,6 +153,7 @@ class HomeViewModel @Inject constructor(
             updateState {
                 copy(
                     userName = userInfo.name,
+                    userNickName = userInfo.nickname,
                     gisuTag = gisuTags
                 )
             }
@@ -358,6 +359,7 @@ data class HomeFragmentUiState(
 
     // 유저 정보 영역
     val userName: String = "",
+    val userNickName: String = "",
     val growDay: Int = 0,
     val gisuTag: List<String> = emptyList(),
 

--- a/presentation/src/main/java/com/umc/presentation/ui/home/PlanAddViewModel.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/home/PlanAddViewModel.kt
@@ -430,7 +430,7 @@ data class PlanAddFragmentUiState(
         CategoryItem(CategoryType.HACKATHON.label, R.drawable.ic_hackathon_off, R.drawable.ic_hackathon_on),
         CategoryItem(CategoryType.WORKSHOP.label, R.drawable.ic_workshop_off, R.drawable.ic_workshop_on),
         /**아이콘 임시조치**/
-        CategoryItem(CategoryType.AFTER_PARTY.label, R.drawable.ic_leadership_off, R.drawable.ic_leadership_off)
+        CategoryItem(CategoryType.AFTER_PARTY.label, R.drawable.ic_afterparty_off, R.drawable.ic_afterparty_on)
 
         ),
     val isSelectedCategory: Boolean = false, //UI에 placeholder or text 보여줄지 판단하는 변수

--- a/presentation/src/main/java/com/umc/presentation/ui/home/PlanAddViewModel.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/home/PlanAddViewModel.kt
@@ -429,7 +429,10 @@ data class PlanAddFragmentUiState(
         CategoryItem(CategoryType.STUDY.label, R.drawable.ic_study_off, R.drawable.ic_study_on),
         CategoryItem(CategoryType.HACKATHON.label, R.drawable.ic_hackathon_off, R.drawable.ic_hackathon_on),
         CategoryItem(CategoryType.WORKSHOP.label, R.drawable.ic_workshop_off, R.drawable.ic_workshop_on),
-    ),
+        /**아이콘 임시조치**/
+        CategoryItem(CategoryType.AFTER_PARTY.label, R.drawable.ic_leadership_off, R.drawable.ic_leadership_off)
+
+        ),
     val isSelectedCategory: Boolean = false, //UI에 placeholder or text 보여줄지 판단하는 변수
     val selectedCategoriesString: String = ""
     

--- a/presentation/src/main/java/com/umc/presentation/ui/splash/SplashViewModel.kt
+++ b/presentation/src/main/java/com/umc/presentation/ui/splash/SplashViewModel.kt
@@ -1,6 +1,9 @@
 package com.umc.presentation.ui.splash
 
+import android.util.Log
 import androidx.lifecycle.viewModelScope
+import com.kakao.sdk.auth.TokenManagerProvider
+import com.kakao.sdk.user.UserApiClient
 import com.umc.domain.model.UserInfo
 import com.umc.domain.usecase.member.GetMyProfileUseCase
 import com.umc.presentation.base.BaseViewModel
@@ -24,6 +27,14 @@ class SplashViewModel @Inject constructor(
     private fun initFun() {
         viewModelScope.launch {
             delay(3.seconds)
+
+            /*
+            TokenManagerProvider.instance.manager.getToken()?.let { token ->
+                Log.d("KakaoToken", "카카오 accessToken: ${token.accessToken}")
+            }
+
+             */
+
             resultResponse(
                 response = getMyProfileUseCase(),
                 successCallback = { userInfo ->

--- a/presentation/src/main/res/drawable/ic_afterparty_off.xml
+++ b/presentation/src/main/res/drawable/ic_afterparty_off.xml
@@ -1,0 +1,19 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="48dp"
+    android:height="48dp"
+    android:viewportWidth="48"
+    android:viewportHeight="48">
+  <path
+      android:pathData="M0,8C0,3.582 3.582,0 8,0H40C44.418,0 48,3.582 48,8V40C48,44.418 44.418,48 40,48H8C3.582,48 0,44.418 0,40V8Z"
+      android:fillColor="#F7F8FA"/>
+  <group>
+    <clip-path
+        android:pathData="M12,12h24v24h-24z"/>
+    <path
+        android:pathData="M15,26C15,27.3 15.84,28.4 17,28.82V32H15V34H21V32H19V28.82C20.16,28.4 21,27.3 21,26V18H15V26ZM17,20H19V23H17V20Z"
+        android:fillColor="#B1B5BF"/>
+    <path
+        android:pathData="M32.63,20.54L31.68,20.22C31.28,20.09 31,19.71 31,19.28V15C31,14.45 30.55,14 30,14H27C26.45,14 26,14.45 26,15V19.28C26,19.71 25.72,20.09 25.32,20.23L24.37,20.55C23.55,20.82 23,21.58 23,22.44V32C23,33.1 23.9,34 25,34H32C33.1,34 34,33.1 34,32V22.44C34,21.58 33.45,20.82 32.63,20.54ZM28,16H29V17H28V16ZM25,22.44L25.95,22.12C27.18,21.72 28,20.57 28,19.28V19H29V19.28C29,20.57 29.82,21.72 31.05,22.13L32,22.44V24H25V22.44ZM32,32H25V30H32V32Z"
+        android:fillColor="#B1B5BF"/>
+  </group>
+</vector>

--- a/presentation/src/main/res/drawable/ic_afterparty_on.xml
+++ b/presentation/src/main/res/drawable/ic_afterparty_on.xml
@@ -1,0 +1,19 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="48dp"
+    android:height="48dp"
+    android:viewportWidth="48"
+    android:viewportHeight="48">
+  <path
+      android:pathData="M0,8C0,3.582 3.582,0 8,0H40C44.418,0 48,3.582 48,8V40C48,44.418 44.418,48 40,48H8C3.582,48 0,44.418 0,40V8Z"
+      android:fillColor="#EBEFFF"/>
+  <group>
+    <clip-path
+        android:pathData="M12,12h24v24h-24z"/>
+    <path
+        android:pathData="M15,26C15,27.3 15.84,28.4 17,28.82V32H15V34H21V32H19V28.82C20.16,28.4 21,27.3 21,26V18H15V26ZM17,20H19V23H17V20Z"
+        android:fillColor="#4869F0"/>
+    <path
+        android:pathData="M32.63,20.54L31.68,20.22C31.28,20.09 31,19.71 31,19.28V15C31,14.45 30.55,14 30,14H27C26.45,14 26,14.45 26,15V19.28C26,19.71 25.72,20.09 25.32,20.23L24.37,20.55C23.55,20.82 23,21.58 23,22.44V32C23,33.1 23.9,34 25,34H32C33.1,34 34,33.1 34,32V22.44C34,21.58 33.45,20.82 32.63,20.54ZM28,16H29V17H28V16ZM25,22.44L25.95,22.12C27.18,21.72 28,20.57 28,19.28V19H29V19.28C29,20.57 29.82,21.72 31.05,22.13L32,22.44V24H25V22.44ZM32,32H25V30H32V32Z"
+        android:fillColor="#4869F0"/>
+  </group>
+</vector>

--- a/presentation/src/main/res/layout/fragment_home.xml
+++ b/presentation/src/main/res/layout/fragment_home.xml
@@ -143,7 +143,7 @@
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_marginTop="16dp"
-                            android:text="@{vm.uiState.userName}"
+                            android:text="@{vm.uiState.userName + '/' + vm.uiState.userNickName}"
                             android:textColor="@color/neutral700"
                             android:textAppearance="@style/Title3"
                             app:layout_constraintStart_toStartOf="parent"

--- a/presentation/src/main/res/layout/fragment_mypage.xml
+++ b/presentation/src/main/res/layout/fragment_mypage.xml
@@ -85,7 +85,7 @@
                 android:gravity="start"
                 android:textAppearance="@style/Title3Bold"
                 android:textColor="@color/neutral800"
-                android:text="@{vm.uiState.userInfo.name}"
+                android:text="@{vm.uiState.userInfo.name + '/' + vm.uiState.userInfo.nickname}"
                 android:layout_marginStart="8dp"
                 app:layout_constraintStart_toEndOf="@id/mypage_circleimv_profile"
                 app:layout_constraintTop_toTopOf="parent"

--- a/presentation/src/main/res/layout/item_community_content.xml
+++ b/presentation/src/main/res/layout/item_community_content.xml
@@ -79,7 +79,7 @@
             android:gravity="start"
             android:textAppearance="@style/SubheadlineBold"
             android:textColor="@color/neutral800"
-            android:text="@{item.username}"
+            android:text='@{item.username.equals("") ? "알 수 없음" : item.username + "/" + item.userNickName}'
             android:layout_marginTop="16dp"
             android:layout_marginStart="8dp"
             app:layout_constraintStart_toEndOf="@id/item_circleimv_profile"

--- a/presentation/src/main/res/layout/item_mypage_content.xml
+++ b/presentation/src/main/res/layout/item_mypage_content.xml
@@ -77,7 +77,7 @@
                     android:id="@+id/item_tv_username"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="@{item.username}"
+                    android:text='@{item.username.equals("") ? "알 수 없음" : item.username + "/" + item.userNickName}'
                     android:textColor="@color/neutral600"
                     android:textAppearance="@style/Footnote"
                     tools:text="유저이름" />


### PR DESCRIPTION
## #️⃣ 이슈 번호

> 관련된 이슈 번호를 적어주세요.\
> Close #150

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 요약해주세요.

1. 일정 카테고리 탭에 뒤풀이(AFTER_PARTY) 추가 (enum 및 이미지 적용)
2. 홈/마이페이지/커뮤니티에서 `이름/닉네임` 형식으로 출력되도록 수정 (단 댓글은 현재 닉네임 정보 X)
3. 커뮤니티 API response 변경으로 충돌 해결
4. 댓글 순서 조정(먼저 작성된 것이 위로 가도록)

## 📸 스크린샷 (선택 사항)
| 설명 | 이미지 |
| :---: | :---: |
|  |  |

## 🚩 리뷰 요구사항
> 리뷰어가 중점적으로 봐주었으면 하는 부분이 있다면 작성해주세요.

## 🏁 체크리스트
- [ ] 코딩 컨벤션을 준수했나요?
- [ ] 불필요한 로그나 주석을 제거했나요?
- [ ] 머지 대상 브랜치(Base branch)가 올바른가요?
